### PR TITLE
add function get_user_funding_history

### DIFF
--- a/hyperliquid/info.py
+++ b/hyperliquid/info.py
@@ -196,6 +196,31 @@ class Info(API):
             )
         return self.post("/info", {"type": "fundingHistory", "coin": coin, "startTime": startTime})
 
+    def user_funding_history(self, user: str, startTime: int, endTime: Optional[int] = None) -> Any:
+        """Retrieve a user's funding history
+
+        POST /info
+
+        Args:
+            user (str): Address of the user in 42-character hexadecimal format.
+            startTime (int): Start time in milliseconds, inclusive.
+            endTime (int, optional): End time in milliseconds, inclusive. Defaults to current time.
+
+        Returns:
+            List[Dict]: A list of funding history records, where each record contains:
+                - user (str): User address.
+                - type (str): Type of the record, e.g., "userFunding".
+                - startTime (int): Unix timestamp of the start time in milliseconds.
+                - endTime (int): Unix timestamp of the end time in milliseconds.
+        """
+        if endTime is not None:
+            return self.post(
+                "/info", {"type": "userFunding", "user": user, "startTime": startTime, "endTime": endTime}
+            )
+        return self.post(
+            "/info", {"type": "userFunding", "user": user, "startTime": startTime}
+        )
+
     def l2_snapshot(self, coin: str) -> Any:
         """Retrieve L2 snapshot for a given coin
 

--- a/tests/info_test.py
+++ b/tests/info_test.py
@@ -87,3 +87,39 @@ def test_get_candles_snapshot():
     assert len(response) == 24
     for key in ["T", "c", "h", "i", "l", "n", "o", "s", "t", "v"]:
         assert key in response[0].keys()
+
+
+@pytest.mark.vcr()
+def test_user_funding_history_with_end_time():
+    info = Info(skip_ws=True)
+    response = info.user_funding_history(
+        user="0xb7b6f3cea3f66bf525f5d8f965f6dbf6d9b017b2",
+        startTime=1681923833000,
+        endTime=1682010233000
+    )
+    assert isinstance(response, list), "The answer should be a list"
+    for record in response:
+        assert 'delta' in record, "There must be a key 'delta'"
+        assert 'hash' in record, "There must be a key 'hash'"
+        assert 'time' in record, "There must be a key 'time'"
+        delta = record['delta']
+        for key in ['coin', 'fundingRate', 'szi', 'type', 'usdc']:
+            assert key in delta, f"В 'delta' There must be a key '{key}'"
+        assert delta['type'] == 'funding', "The type must be 'funding'"
+
+@pytest.mark.vcr()
+def test_user_funding_history_without_end_time():
+    info = Info(skip_ws=True)
+    response = info.user_funding_history(
+        user="0xb7b6f3cea3f66bf525f5d8f965f6dbf6d9b017b2",
+        startTime=1681923833000
+    )
+    assert isinstance(response, list), "The answer must be a list"
+    for record in response:
+        assert 'delta' in record, "There must be a key 'delta'"
+        assert 'hash' in record, "There must be a key 'hash'"
+        assert 'time' in record, "There must be a key 'time'"
+        delta = record['delta']
+        for key in ['coin', 'fundingRate', 'szi', 'type', 'usdc']:
+            assert key in delta, f"В 'delta' There must be a '{key}'"
+        assert delta['type'] == 'funding', "The type must be 'funding'"


### PR DESCRIPTION
Hi! I needed a function to count user's funding, but I didn't find it in the SDK. Therefore, I decided to add it myself. This feature allows users to get a funding history at their account address, which is quite important for analyzing financial transactions on the platform

I added a new get_user_funding_history method that does just that, and wrote a couple of tests to check how it works: one with an end time, the other without it