### PR TITLE
Add user_fees method to hyperliquid/info.py to retrieve user's volume…

### DIFF
--- a/hyperliquid/info.py
+++ b/hyperliquid/info.py
@@ -54,55 +54,6 @@ class Info(API):
         """
         return self.post("/info", {"type": "clearinghouseState", "user": address})
     
-    def user_fees(self, address: str) -> Any:
-        """Retrieve the volume of trading activity associated with a user.
-
-        POST /info
-
-        Args:
-            address (str): Onchain address in 42-character hexadecimal format;
-                            e.g. 0x0000000000000000000000000000000000000000.
-
-        Returns:
-            {
-                activeReferralDiscount: str,
-                dailyUserVlm: [
-                    {
-                        date: str,
-                        exchange: str,
-                        userAdd: str,
-                        userCross: str
-                    },
-                    ...
-                ],
-                feeSchedule: {
-                    add: str,
-                    cross: str,
-                    referralDiscount: str,
-                    tiers: {
-                        mm: [
-                            {
-                                add: str,
-                                makerFractionCutoff: float
-                            },
-                            ...
-                        ],
-                        vip: [
-                            {
-                                add: str,
-                                cross: str,
-                                ntlCutoff: float
-                            },
-                            ...
-                        ]
-                    }
-                },
-                userAddRate: str,
-                userCrossRate: str
-            }
-        """
-        return self.post("/info", {"type": "userFees", "user": address})
-
     def spot_user_state(self, address: str) -> Any:
         return self.post("/info", {"type": "spotClearinghouseState", "user": address})
 
@@ -349,6 +300,54 @@ class Info(API):
         """
         req = {"coin": coin, "interval": interval, "startTime": startTime, "endTime": endTime}
         return self.post("/info", {"type": "candleSnapshot", "req": req})
+
+    def user_fees(self, address: str) -> Any:
+        """Retrieve the volume of trading activity associated with a user.
+
+        POST /info
+
+        Args:
+            address (str): Onchain address in 42-character hexadecimal format;
+                            e.g. 0x0000000000000000000000000000000000000000.
+
+        Returns:
+            {
+                activeReferralDiscount: str,
+                dailyUserVlm: [
+                    {
+                        date: float string,
+                        exchange: float string,
+                        userAdd: float string,
+                        userCross: str
+                    },
+                ],
+                feeSchedule: {
+                    add: str,
+                    cross: str,
+                    referralDiscount: str,
+                    tiers: {
+                        mm: [
+                            {
+                                add: float string,
+                                makerFractionCutoff: float string
+                            },
+                            ...
+                        ],
+                        vip: [
+                            {
+                                add: str,
+                                cross: str,
+                                ntlCutoff: float
+                            },
+                            ...
+                        ]
+                    }
+                },
+                userAddRate: str,
+                userCrossRate: str
+            }
+        """
+        return self.post("/info", {"type": "userFees", "user": address})
 
     def query_order_by_oid(self, user: str, oid: int) -> Any:
         return self.post("/info", {"type": "orderStatus", "user": user, "oid": oid})

--- a/hyperliquid/info.py
+++ b/hyperliquid/info.py
@@ -53,6 +53,55 @@ class Info(API):
                 }
         """
         return self.post("/info", {"type": "clearinghouseState", "user": address})
+    
+    def user_fees(self, address: str) -> Any:
+        """Retrieve the volume of trading activity associated with a user.
+
+        POST /info
+
+        Args:
+            address (str): Onchain address in 42-character hexadecimal format;
+                            e.g. 0x0000000000000000000000000000000000000000.
+
+        Returns:
+            {
+                activeReferralDiscount: str,
+                dailyUserVlm: [
+                    {
+                        date: str,
+                        exchange: str,
+                        userAdd: str,
+                        userCross: str
+                    },
+                    ...
+                ],
+                feeSchedule: {
+                    add: str,
+                    cross: str,
+                    referralDiscount: str,
+                    tiers: {
+                        mm: [
+                            {
+                                add: str,
+                                makerFractionCutoff: float
+                            },
+                            ...
+                        ],
+                        vip: [
+                            {
+                                add: str,
+                                cross: str,
+                                ntlCutoff: float
+                            },
+                            ...
+                        ]
+                    }
+                },
+                userAddRate: str,
+                userCrossRate: str
+            }
+        """
+        return self.post("/info", {"type": "userFees", "user": address})
 
     def spot_user_state(self, address: str) -> Any:
         return self.post("/info", {"type": "spotClearinghouseState", "user": address})

--- a/hyperliquid/info.py
+++ b/hyperliquid/info.py
@@ -312,39 +312,37 @@ class Info(API):
 
         Returns:
             {
-                activeReferralDiscount: str,
+                activeReferralDiscount: float string,
                 dailyUserVlm: [
                     {
-                        date: float string,
-                        exchange: float string,
+                        date: str,
+                        exchange: str,
                         userAdd: float string,
-                        userCross: str
+                        userCross: float string
                     },
                 ],
                 feeSchedule: {
-                    add: str,
-                    cross: str,
-                    referralDiscount: str,
+                    add: float string,
+                    cross: float string,
+                    referralDiscount: float string,
                     tiers: {
                         mm: [
                             {
                                 add: float string,
                                 makerFractionCutoff: float string
                             },
-                            ...
                         ],
                         vip: [
                             {
-                                add: str,
-                                cross: str,
-                                ntlCutoff: float
+                                add: float string,
+                                cross: float string,
+                                ntlCutoff: float string
                             },
-                            ...
                         ]
                     }
                 },
-                userAddRate: str,
-                userCrossRate: str
+                userAddRate: float string,
+                userCrossRate: float string
             }
         """
         return self.post("/info", {"type": "userFees", "user": address})


### PR DESCRIPTION
Add a method to retrieve user trading fees and volume information

This commit introduces a new method **user_fees** in the **Info** class that fetches and returns detailed information about the trading fees and volumes associated with a specific user. It includes the active referral discount rate, daily trading volume breakdown by user, and a detailed fee schedule. This enhancement will allow developers and users to track trading activities and fees more efficiently.

This enhancement was implemented after failing to find the necessary information in the official documentation and support. The need for this functionality was confirmed through discussions in the community Discord chat. This method will allow developers and users to track trading activities and fees more efficiently.