### PR TITLE
Update position to 0 when user assetPositions is empty

### DIFF
--- a/examples/basic_adding.py
+++ b/examples/basic_adding.py
@@ -33,7 +33,7 @@ ALLOWABLE_DEVIATION = 0.5
 
 # The maximum absolute position value the strategy can accumulate in units of the coin.
 # i.e. the strategy will place orders such that it can long up to 1 ETH or short up to 1 ETH
-MAX_POSITION = 0.01
+MAX_POSITION = 1.0
 
 # The coin to add liquidity on
 COIN = "ETH"


### PR DESCRIPTION
If `user_state["assetPositions"]` is empty, as it would be for new users. `self.position` is always `None` and no orders will be sent (line 108).

Also reduce `MAX_POSITION` TO `0.01`, otherwise there is not enough margin from 100 mock USDC