### PR TITLE
Update spot meta types

### DIFF
--- a/hyperliquid/utils/types.py
+++ b/hyperliquid/utils/types.py
@@ -22,8 +22,11 @@ Meta = TypedDict("Meta", {"universe": List[AssetInfo]})
 Side = Union[Literal["A"], Literal["B"]]
 SIDES: List[Side] = ["A", "B"]
 
-SpotAssetInfo = TypedDict("SpotAssetInfo", {"name": str, "tokens": List[int]})
-SpotTokenInfo = TypedDict("SpotTokenInfo", {"name": str, "szDecimals": int, "weiDecimals": int})
+SpotAssetInfo = TypedDict("SpotAssetInfo", {"name": str, "tokens": List[int], "index": int, "isCanonical": bool})
+SpotTokenInfo = TypedDict(
+    "SpotTokenInfo",
+    {"name": str, "szDecimals": int, "weiDecimals": int, "index": int, "tokenId": str, "isCanonical": bool},
+)
 SpotMeta = TypedDict("SpotMeta", {"universe": List[SpotAssetInfo], "tokens": List[SpotTokenInfo]})
 
 AllMidsSubscription = TypedDict("AllMidsSubscription", {"type": Literal["allMids"]})


### PR DESCRIPTION
This adds missing fields to spot meta response types.

Example server response for reference:

  ```json
{
    "universe": [
        {
            "tokens": [
                1,
                0
            ],
            "name": "PURR/USDC",
            "index": 0,
            "isCanonical": true
        },
        {
            "tokens": [
                2,
                0
            ],
            "name": "@1",
            "index": 1,
            "isCanonical": false
        },
        {
            "tokens": [
                3,
                0
            ],
            "name": "@2",
            "index": 2,
            "isCanonical": false
        },
        {
            "tokens": [
                4,
                0
            ],
            "name": "@3",
            "index": 3,
            "isCanonical": false
        },
        {
            "tokens": [
                5,
                0
            ],
            "name": "@4",
            "index": 4,
            "isCanonical": false
        },
        {
            "tokens": [
                6,
                0
            ],
            "name": "@5",
            "index": 5,
            "isCanonical": false
        },
        {
            "tokens": [
                7,
                0
            ],
            "name": "@6",
            "index": 6,
            "isCanonical": false
        },
        {
            "tokens": [
                8,
                0
            ],
            "name": "@7",
            "index": 7,
            "isCanonical": false
        },
        {
            "tokens": [
                9,
                0
            ],
            "name": "@8",
            "index": 8,
            "isCanonical": false
        },
        {
            "tokens": [
                10,
                0
            ],
            "name": "@9",
            "index": 9,
            "isCanonical": false
        },
        {
            "tokens": [
                11,
                0
            ],
            "name": "@10",
            "index": 10,
            "isCanonical": false
        },
        {
            "tokens": [
                12,
                0
            ],
            "name": "@11",
            "index": 11,
            "isCanonical": false
        },
        {
            "tokens": [
                13,
                0
            ],
            "name": "@12",
            "index": 12,
            "isCanonical": false
        },
        {
            "tokens": [
                14,
                0
            ],
            "name": "@13",
            "index": 13,
            "isCanonical": false
        },
        {
            "tokens": [
                15,
                0
            ],
            "name": "@14",
            "index": 14,
            "isCanonical": false
        },
        {
            "tokens": [
                16,
                0
            ],
            "name": "@15",
            "index": 15,
            "isCanonical": false
        }
    ],
    "tokens": [
        {
            "name": "USDC",
            "szDecimals": 8,
            "weiDecimals": 8,
            "index": 0,
            "tokenId": "0x6d1e7cde53ba9467b783cb7c530ce054",
            "isCanonical": true
        },
        {
            "name": "PURR",
            "szDecimals": 0,
            "weiDecimals": 5,
            "index": 1,
            "tokenId": "0xc1fb593aeffbeb02f85e0308e9956a90",
            "isCanonical": true
        },
        {
            "name": "HFUN",
            "szDecimals": 2,
            "weiDecimals": 8,
            "index": 2,
            "tokenId": "0xbaf265ef389da684513d98d68edf4eae",
            "isCanonical": false
        },
        {
            "name": "LICK",
            "szDecimals": 0,
            "weiDecimals": 5,
            "index": 3,
            "tokenId": "0xba3aaf468f793d9b42fd3328e24f1de9",
            "isCanonical": false
        },
        {
            "name": "MANLET",
            "szDecimals": 0,
            "weiDecimals": 5,
            "index": 4,
            "tokenId": "0xe9ced9225d2a69ccc8d6a5b224524b99",
            "isCanonical": false
        },
        {
            "name": "JEFF",
            "szDecimals": 0,
            "weiDecimals": 5,
            "index": 5,
            "tokenId": "0xfcf28885456bf7e7cbe5b7a25407c5bc",
            "isCanonical": false
        },
        {
            "name": "SIX",
            "szDecimals": 2,
            "weiDecimals": 8,
            "index": 6,
            "tokenId": "0x50a9391b4a40caffbe8b16303b95a0c1",
            "isCanonical": false
        },
        {
            "name": "WAGMI",
            "szDecimals": 2,
            "weiDecimals": 8,
            "index": 7,
            "tokenId": "0x649efea44690cf88d464f512bc7e2818",
            "isCanonical": false
        },
        {
            "name": "CAPPY",
            "szDecimals": 0,
            "weiDecimals": 5,
            "index": 8,
            "tokenId": "0x3f8abf62220007cc7ab6d33ef2963d88",
            "isCanonical": false
        },
        {
            "name": "POINTS",
            "szDecimals": 0,
            "weiDecimals": 5,
            "index": 9,
            "tokenId": "0xbb03842e1f71ed27ed8fa012b29affd4",
            "isCanonical": false
        },
        {
            "name": "TRUMP",
            "szDecimals": 2,
            "weiDecimals": 7,
            "index": 10,
            "tokenId": "0x368cb581f0d51e21aa19996d38ffdf6f",
            "isCanonical": false
        },
        {
            "name": "GMEOW",
            "szDecimals": 0,
            "weiDecimals": 8,
            "index": 11,
            "tokenId": "0x07615193eaa63d1da6feda6e0ac9e014",
            "isCanonical": false
        },
        {
            "name": "PEPE",
            "szDecimals": 2,
            "weiDecimals": 7,
            "index": 12,
            "tokenId": "0x79b6e1596ea0deb2e6912ff8392c9325",
            "isCanonical": false
        },
        {
            "name": "XULIAN",
            "szDecimals": 0,
            "weiDecimals": 5,
            "index": 13,
            "tokenId": "0x6cc648be7e4c38a8c7fcd8bfa6714127",
            "isCanonical": false
        },
        {
            "name": "RUG",
            "szDecimals": 0,
            "weiDecimals": 5,
            "index": 14,
            "tokenId": "0x4978f3f49f30776d9d7397b873223c2d",
            "isCanonical": false
        },
        {
            "name": "ILIENS",
            "szDecimals": 0,
            "weiDecimals": 5,
            "index": 15,
            "tokenId": "0xa74984ea379be6d899c1bf54db923604",
            "isCanonical": false
        },
        {
            "name": "FUCKY",
            "szDecimals": 2,
            "weiDecimals": 8,
            "index": 16,
            "tokenId": "0x7de5b7a8c115edf0174333446ba0ea78",
            "isCanonical": false
        },
        {
            "name": "CZ",
            "szDecimals": 2,
            "weiDecimals": 7,
            "index": 17,
            "tokenId": "0x3b5ff6cb91f71032578b53960090adfb",
            "isCanonical": false
        }
    ]
}
```
