### PR TITLE
Update the slippage function to work correctly with spot precision

### DIFF
--- a/hyperliquid/exchange.py
+++ b/hyperliquid/exchange.py
@@ -78,11 +78,14 @@ class Exchange(API):
         is_buy: bool,
         slippage: float,
         px: Optional[float] = None,
-        is_spot: bool = False,
     ) -> float:
         if not px:
             # Get midprice
             px = float(self.info.all_mids()[coin])
+        
+        # spot assets start at 10000
+        is_spot = self.coin_to_asset.get(coin) >= 10_000
+
         # Calculate Slippage
         px *= (1 + slippage) if is_buy else (1 - slippage)
         # We round px to 5 significant figures and 6 decimals for perps, 8 decimals for spot
@@ -194,10 +197,9 @@ class Exchange(API):
         px: Optional[float] = None,
         slippage: float = DEFAULT_SLIPPAGE,
         cloid: Optional[Cloid] = None,
-        is_spot: bool = False,
     ) -> Any:
         # Get aggressive Market Price
-        px = self._slippage_price(coin, is_buy, slippage, px, is_spot)
+        px = self._slippage_price(coin, is_buy, slippage, px)
         # Market Order is an aggressive Limit Order IoC
         return self.order(coin, is_buy, sz, px, order_type={"limit": {"tif": "Ioc"}}, reduce_only=False, cloid=cloid)
 
@@ -208,7 +210,6 @@ class Exchange(API):
         px: Optional[float] = None,
         slippage: float = DEFAULT_SLIPPAGE,
         cloid: Optional[Cloid] = None,
-        is_spot: bool = False,
     ) -> Any:
         address = self.wallet.address
         if self.account_address:
@@ -225,7 +226,7 @@ class Exchange(API):
                 sz = abs(szi)
             is_buy = True if szi < 0 else False
             # Get aggressive Market Price
-            px = self._slippage_price(coin, is_buy, slippage, px, is_spot)
+            px = self._slippage_price(coin, is_buy, slippage, px)
             # Market Order is an aggressive Limit Order IoC
             return self.order(coin, is_buy, sz, px, order_type={"limit": {"tif": "Ioc"}}, reduce_only=True, cloid=cloid)
 


### PR DESCRIPTION
As stated in the [docs](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size), the price can have up to 8 decimals for spot.