### PR TITLE
feat(hl/types): Update `SpotTokenInfo` to reflect current API responses

### DIFF
--- a/hyperliquid/utils/types.py
+++ b/hyperliquid/utils/types.py
@@ -25,7 +25,7 @@ SIDES: List[Side] = ["A", "B"]
 SpotAssetInfo = TypedDict("SpotAssetInfo", {"name": str, "tokens": List[int], "index": int, "isCanonical": bool})
 SpotTokenInfo = TypedDict(
     "SpotTokenInfo",
-    {"name": str, "szDecimals": int, "weiDecimals": int, "index": int, "tokenId": str, "isCanonical": bool, "evmContract": Union[str, None], "fullName": Union[str, None]},
+    {"name": str, "szDecimals": int, "weiDecimals": int, "index": int, "tokenId": str, "isCanonical": bool, "evmContract": Optional[str], "fullName": Optional[str]},
 )
 SpotMeta = TypedDict("SpotMeta", {"universe": List[SpotAssetInfo], "tokens": List[SpotTokenInfo]})
 SpotAssetCtx = TypedDict(

--- a/hyperliquid/utils/types.py
+++ b/hyperliquid/utils/types.py
@@ -25,7 +25,7 @@ SIDES: List[Side] = ["A", "B"]
 SpotAssetInfo = TypedDict("SpotAssetInfo", {"name": str, "tokens": List[int], "index": int, "isCanonical": bool})
 SpotTokenInfo = TypedDict(
     "SpotTokenInfo",
-    {"name": str, "szDecimals": int, "weiDecimals": int, "index": int, "tokenId": str, "isCanonical": bool},
+    {"name": str, "szDecimals": int, "weiDecimals": int, "index": int, "tokenId": str, "isCanonical": bool, "evmContract": Union[str, None], "fullName": Union[str, None]},
 )
 SpotMeta = TypedDict("SpotMeta", {"universe": List[SpotAssetInfo], "tokens": List[SpotTokenInfo]})
 SpotAssetCtx = TypedDict(


### PR DESCRIPTION
The `/info` endpoint while requesting `spotMeta` currently returns additional `evmContract` & `fullName` properties for tokens.

This adds the missing fields.

Example response:
```
{
  "universe": [
    ...
  ],
  "tokens": [
    ...,
    {
      "name": "MBAPPE",
      "szDecimals": 2,
      "weiDecimals": 7,
      "index": 50,
      "tokenId": "0x03e1ad7d4d6d82b3da89ac8d35cc917b",
      "isCanonical": false,
      "evmContract": null,
      "fullName": "MBENIVINI"
    }
  ]
}
```