### PR TITLE
Typo Update info_test.py

### DIFF
--- a/tests/info_test.py
+++ b/tests/info_test.py
@@ -106,7 +106,7 @@ def test_user_funding_history_with_end_time():
         assert "time" in record, "There must be a key 'time'"
         delta = record["delta"]
         for key in ["coin", "fundingRate", "szi", "type", "usdc"]:
-            assert key in delta, f"В 'delta' There must be a key '{key}'"
+            assert key in delta, f"There must be a key '{key}' in 'delta'"
         assert delta["type"] == "funding", "The type must be 'funding'"
 
 
@@ -121,5 +121,5 @@ def test_user_funding_history_without_end_time():
         assert "time" in record, "There must be a key 'time'"
         delta = record["delta"]
         for key in ["coin", "fundingRate", "szi", "type", "usdc"]:
-            assert key in delta, f"В 'delta' There must be a '{key}'"
+            assert key in delta, f"There must be a key '{key}' in 'delta'"
         assert delta["type"] == "funding", "The type must be 'funding'"


### PR DESCRIPTION
Description of Changes
In this pull request, I made minor adjustments to the error assertion messages in test cases for better clarity and consistency. Here’s what was changed:

Unified error messages: Updated phrases like "В 'delta' There must be a key..." to "There must be a key... in 'delta'" for clearer, single-language communication.