### PR TITLE
Add graceful shutdown logic for WebSocket

### DIFF
--- a/hyperliquid/info.py
+++ b/hyperliquid/info.py
@@ -526,3 +526,8 @@ class Info(API):
 
     def name_to_asset(self, name: str) -> int:
         return self.coin_to_asset[self.name_to_coin[name]]
+
+    def close(self):
+        if not hasattr(self, "ws_manager") or self.ws_manager is None:
+            return
+        self.ws_manager.stop()

--- a/hyperliquid/info.py
+++ b/hyperliquid/info.py
@@ -25,6 +25,8 @@ class Info(API):
         if not skip_ws:
             self.ws_manager = WebsocketManager(self.base_url)
             self.ws_manager.start()
+        else:
+            self.ws_manager = None
         if meta is None:
             meta = self.meta()
 
@@ -42,6 +44,12 @@ class Info(API):
             name = f'{spot_meta["tokens"][base]["name"]}/{spot_meta["tokens"][quote]["name"]}'
             if name not in self.name_to_coin:
                 self.name_to_coin[name] = spot_info["name"]
+
+    def disconnect_websocket(self):
+        if self.ws_manager is None:
+            raise RuntimeError("Cannot call disconnect_websocket since skip_ws was used")
+        else:
+            self.ws_manager.stop()
 
     def user_state(self, address: str) -> Any:
         """Retrieve trading details about a user.
@@ -526,8 +534,3 @@ class Info(API):
 
     def name_to_asset(self, name: str) -> int:
         return self.coin_to_asset[self.name_to_coin[name]]
-
-    def close(self):
-        if not hasattr(self, "ws_manager") or self.ws_manager is None:
-            return
-        self.ws_manager.stop()

--- a/hyperliquid/websocket_manager.py
+++ b/hyperliquid/websocket_manager.py
@@ -71,14 +71,15 @@ class WebsocketManager(threading.Thread):
         self.ping_sender = threading.Thread(target=self.send_ping)
 
     def run(self):
-        self.ping_sender.start()
         self.ws.run_forever()
+        self.ping_sender.start()
 
     def send_ping(self):
-        while True:
+        while self.ws.run_forever:
             time.sleep(50)
             logging.debug("Websocket sending ping")
             self.ws.send(json.dumps({"method": "ping"}))
+        logging.debug("Websocket ping sender stopped")
 
     def on_message(self, _ws, message):
         if message == "Websocket connection established.":
@@ -136,3 +137,8 @@ class WebsocketManager(threading.Thread):
             self.ws.send(json.dumps({"method": "unsubscribe", "subscription": subscription}))
         self.active_subscriptions[identifier] = new_active_subscriptions
         return len(active_subscriptions) != len(new_active_subscriptions)
+
+    def stop(self):
+        if not self.ws.keep_running:
+            return
+        self.ws.close()


### PR DESCRIPTION
Before these changes, if the WebSocket client is created, the program cannot be shut down until the key interruption occurs due to the keepalive thread. This PR adds the graceful shutdown logic for WebSocket client within `Info`. 

Close #24.

Call `disconnect_websocket()` when `skip_ws=True`:

<img width="1276" alt="图片" src="https://github.com/user-attachments/assets/5a3203c6-9d43-455e-90fd-612506403659">