### PR TITLE
Refactor is_mainnet, add multisig validation, and update readme for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ python examples/basic_order.py
 make install
 ```
 
+4. Run your local code with poetry
+
+```bash
+poetry run python examples/basic_order
+```
+
 ### Makefile usage
 
 CLI commands for faster development.

--- a/hyperliquid/exchange.py
+++ b/hyperliquid/exchange.py
@@ -53,6 +53,10 @@ class Exchange(API):
         self.account_address = account_address
         self.info = Info(base_url, True, meta, spot_meta)
 
+    @property
+    def is_mainnet(self) -> bool:
+        return self.base_url == MAINNET_API_URL
+
     def _post_action(self, action, signature, nonce):
         payload = {
             "action": action,
@@ -121,7 +125,7 @@ class Exchange(API):
             order_action,
             self.vault_address,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
 
         return self._post_action(
@@ -175,7 +179,7 @@ class Exchange(API):
             modify_action,
             self.vault_address,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
 
         return self._post_action(
@@ -261,7 +265,7 @@ class Exchange(API):
             cancel_action,
             self.vault_address,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
 
         return self._post_action(
@@ -288,7 +292,7 @@ class Exchange(API):
             cancel_action,
             self.vault_address,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
 
         return self._post_action(
@@ -316,7 +320,7 @@ class Exchange(API):
             schedule_cancel_action,
             self.vault_address,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
         return self._post_action(
             schedule_cancel_action,
@@ -337,7 +341,7 @@ class Exchange(API):
             update_leverage_action,
             self.vault_address,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
         return self._post_action(
             update_leverage_action,
@@ -359,7 +363,7 @@ class Exchange(API):
             update_isolated_margin_action,
             self.vault_address,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
         return self._post_action(
             update_isolated_margin_action,
@@ -378,7 +382,7 @@ class Exchange(API):
             set_referrer_action,
             None,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
         return self._post_action(
             set_referrer_action,
@@ -397,7 +401,7 @@ class Exchange(API):
             create_sub_account_action,
             None,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
         return self._post_action(
             create_sub_account_action,
@@ -417,7 +421,7 @@ class Exchange(API):
             "toPerp": to_perp,
             "nonce": timestamp,
         }
-        signature = sign_usd_class_transfer_action(self.wallet, action, self.base_url == MAINNET_API_URL)
+        signature = sign_usd_class_transfer_action(self.wallet, action, self.is_mainnet)
         return self._post_action(
             action,
             signature,
@@ -437,7 +441,7 @@ class Exchange(API):
             sub_account_transfer_action,
             None,
             timestamp,
-            self.base_url == MAINNET_API_URL,
+            self.is_mainnet,
         )
         return self._post_action(
             sub_account_transfer_action,
@@ -453,8 +457,7 @@ class Exchange(API):
             "isDeposit": is_deposit,
             "usd": usd,
         }
-        is_mainnet = self.base_url == MAINNET_API_URL
-        signature = sign_l1_action(self.wallet, vault_transfer_action, None, timestamp, is_mainnet)
+        signature = sign_l1_action(self.wallet, vault_transfer_action, None, timestamp, self.is_mainnet)
         return self._post_action(
             vault_transfer_action,
             signature,
@@ -464,8 +467,7 @@ class Exchange(API):
     def usd_transfer(self, amount: float, destination: str) -> Any:
         timestamp = get_timestamp_ms()
         action = {"destination": destination, "amount": str(amount), "time": timestamp, "type": "usdSend"}
-        is_mainnet = self.base_url == MAINNET_API_URL
-        signature = sign_usd_transfer_action(self.wallet, action, is_mainnet)
+        signature = sign_usd_transfer_action(self.wallet, action, self.is_mainnet)
         return self._post_action(
             action,
             signature,
@@ -481,8 +483,7 @@ class Exchange(API):
             "time": timestamp,
             "type": "spotSend",
         }
-        is_mainnet = self.base_url == MAINNET_API_URL
-        signature = sign_spot_transfer_action(self.wallet, action, is_mainnet)
+        signature = sign_spot_transfer_action(self.wallet, action, self.is_mainnet)
         return self._post_action(
             action,
             signature,
@@ -492,8 +493,7 @@ class Exchange(API):
     def withdraw_from_bridge(self, amount: float, destination: str) -> Any:
         timestamp = get_timestamp_ms()
         action = {"destination": destination, "amount": str(amount), "time": timestamp, "type": "withdraw3"}
-        is_mainnet = self.base_url == MAINNET_API_URL
-        signature = sign_withdraw_from_bridge_action(self.wallet, action, is_mainnet)
+        signature = sign_withdraw_from_bridge_action(self.wallet, action, self.is_mainnet)
         return self._post_action(
             action,
             signature,
@@ -504,14 +504,13 @@ class Exchange(API):
         agent_key = "0x" + secrets.token_hex(32)
         account = eth_account.Account.from_key(agent_key)
         timestamp = get_timestamp_ms()
-        is_mainnet = self.base_url == MAINNET_API_URL
         action = {
             "type": "approveAgent",
             "agentAddress": account.address,
             "agentName": name or "",
             "nonce": timestamp,
         }
-        signature = sign_agent(self.wallet, action, is_mainnet)
+        signature = sign_agent(self.wallet, action, self.is_mainnet)
         if name is None:
             del action["agentName"]
 
@@ -528,7 +527,7 @@ class Exchange(API):
         timestamp = get_timestamp_ms()
 
         action = {"maxFeeRate": max_fee_rate, "builder": builder, "nonce": timestamp, "type": "approveBuilderFee"}
-        signature = sign_approve_builder_fee(self.wallet, action, self.base_url == MAINNET_API_URL)
+        signature = sign_approve_builder_fee(self.wallet, action, self.is_mainnet)
         return self._post_action(action, signature, timestamp)
 
     def convert_to_multi_sig_user(self, authorized_users: List[str], threshold: int) -> Any:
@@ -543,7 +542,7 @@ class Exchange(API):
             "signers": json.dumps(signers),
             "nonce": timestamp,
         }
-        signature = sign_convert_to_multi_sig_user_action(self.wallet, action, self.base_url == MAINNET_API_URL)
+        signature = sign_convert_to_multi_sig_user_action(self.wallet, action, self.is_mainnet)
         return self._post_action(
             action,
             signature,
@@ -551,6 +550,9 @@ class Exchange(API):
         )
 
     def multi_sig(self, multi_sig_user, inner_action, signatures, nonce, vault_address=None):
+        # Currently, we only support up to 10 authorized users for multi-sig
+        assert len(signatures) <= 10, "Only up to 10 authorized users are supported for multi-sig"
+
         multi_sig_user = multi_sig_user.lower()
         multi_sig_action = {
             "type": "multiSig",
@@ -562,11 +564,10 @@ class Exchange(API):
                 "action": inner_action,
             },
         }
-        is_mainnet = self.base_url == MAINNET_API_URL
         signature = sign_multi_sig_action(
             self.wallet,
             multi_sig_action,
-            is_mainnet,
+            self.is_mainnet,
             vault_address,
             nonce,
         )


### PR DESCRIPTION
A few minor changes for readability

1. Pull `is_mainnet` into a helper property for easy reusability
2. Add validation for multisig to support up to 10 authorized user sigs (per [documentation](https://hyperliquid.gitbook.io/hyperliquid-docs/hyperliquid-l1/multi-sig))
3. Update readme to clarify local dev via poetry