### PR TITLE
Create Order Wrapper to provide simple order interfaces for developers

### DIFF
--- a/assets/images/coverage.svg
+++ b/assets/images/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">42%</text>
-        <text x="80" y="14">42%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">48%</text>
+        <text x="80" y="14">48%</text>
     </g>
 </svg>

--- a/examples/order_examples.py
+++ b/examples/order_examples.py
@@ -7,7 +7,7 @@ from order import Order, OrderSide, TimeInForce
 
 def main():
     # Setup exchange connection
-    address, info, exchange = example_utils.setup(constants.TESTNET_API_URL, skip_ws=True)
+    _, _, exchange = example_utils.setup(constants.TESTNET_API_URL, skip_ws=True)
 
     # Create order wrapper
     order = Order(exchange)

--- a/examples/order_examples.py
+++ b/examples/order_examples.py
@@ -1,0 +1,124 @@
+import example_utils
+
+from hyperliquid.utils import constants
+from hyperliquid.utils.types import Cloid
+from order import Order, OrderSide, TimeInForce
+
+
+def main():
+    # Setup exchange connection
+    address, info, exchange = example_utils.setup(constants.TESTNET_API_URL, skip_ws=True)
+
+    # Create order wrapper
+    order = Order(exchange)
+
+    # Example 1: Simple Market Orders
+    print("\n=== Market Order Examples ===")
+
+    # Market buy 0.1 ETH
+    result = order.market_order(asset="ETH", side=OrderSide.BUY, quantity=0.1, slippage=0.01)  # 1% max slippage
+    print(f"Market Buy Result: {result}")
+
+    # Market sell $1000 worth of BTC
+    result = order.market_order_notional(asset="BTC", side=OrderSide.SELL, notional_amount=1000)  # USD amount
+    print(f"Market Sell (Notional) Result: {result}")
+
+    # Example 2: Limit Orders
+    print("\n=== Limit Order Examples ===")
+
+    # Limit buy 0.1 ETH at $1800
+    result = order.limit_order(
+        asset="ETH", side=OrderSide.BUY, quantity=0.1, price=1800, tif=TimeInForce.GTC  # Good till cancelled
+    )
+    print(f"Limit Buy Result: {result}")
+
+    # Post-only limit sell $2000 worth of ETH at $1900
+    result = order.limit_order_notional(
+        asset="ETH",
+        side=OrderSide.SELL,
+        notional_amount=2000,
+        price=1900,
+        tif=TimeInForce.ALO,  # Add liquidity only (post-only)
+    )
+    print(f"Post-only Limit Sell Result: {result}")
+
+    # Example 3: Stop Loss Orders
+    print("\n=== Stop Loss Examples ===")
+
+    # Market stop loss for long position
+    result = order.stop_loss(
+        asset="ETH",
+        side=OrderSide.SELL,
+        quantity=0.1,
+        trigger_price=1750,
+        is_market=True,  # Market order when triggered
+    )
+    print(f"Market Stop Loss Result: {result}")
+
+    # Limit stop loss for short position
+    result = order.stop_loss(
+        asset="BTC",
+        side=OrderSide.BUY,
+        quantity=0.05,
+        trigger_price=45000,
+        is_market=False,
+        limit_price=45100,  # Limit price when triggered
+    )
+    print(f"Limit Stop Loss Result: {result}")
+
+    # Example 4: Take Profit Orders
+    print("\n=== Take Profit Examples ===")
+
+    # Market take profit
+    result = order.take_profit(asset="ETH", side=OrderSide.SELL, quantity=0.1, trigger_price=2000, is_market=True)
+    print(f"Market Take Profit Result: {result}")
+
+    # Example 5: Bracket Orders
+    print("\n=== Bracket Order Example ===")
+
+    # Entry + Stop Loss + Take Profit
+    cloid = Cloid.from_int(1)  # Optional client order ID
+    results = order.bracket_order(
+        asset="ETH",
+        side=OrderSide.BUY,
+        quantity=0.1,
+        entry_price=1800,
+        stop_loss_price=1750,
+        take_profit_price=1900,
+        entry_type=TimeInForce.GTC,
+        is_market_tp_sl=True,
+        cloid=cloid,
+    )
+    print(f"Bracket Order Results:")
+    print(f"Entry Order: {results[0]}")
+    if len(results) > 1:
+        print(f"Stop Loss Order: {results[1]}")
+        print(f"Take Profit Order: {results[2]}")
+
+    # Example 6: Order Modification
+    print("\n=== Order Modification Example ===")
+
+    # Place a limit order first
+    order_result = order.limit_order(
+        asset="ETH", side=OrderSide.BUY, quantity=0.1, price=1750, tif=TimeInForce.GTC, cloid=Cloid.from_int(2)
+    )
+
+    # Modify the order if it's resting
+    if order_result["status"] == "ok":
+        status = order_result["response"]["data"]["statuses"][0]
+        if "resting" in status:
+            oid = status["resting"]["oid"]
+            # Modify order price and quantity
+            modify_result = order.modify_order(
+                oid_or_cloid=oid,
+                asset="ETH",
+                side=OrderSide.BUY,
+                quantity=0.15,  # New quantity
+                price=1760,  # New price
+                tif=TimeInForce.GTC,
+            )
+            print(f"Order Modification Result: {modify_result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/order.py
+++ b/order.py
@@ -1,36 +1,44 @@
+from typing import Any, Dict, List, Optional, Union
+
 from enum import Enum
-from typing import Optional, Union, Dict, Any, List
 
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils.types import BuilderInfo, Cloid
 
+
 class TimeInForce(Enum):
     """Time in force options for orders"""
+
     GTC = "Gtc"  # Good till cancelled
     IOC = "Ioc"  # Immediate or cancel
     ALO = "Alo"  # Add liquidity only (post-only)
 
+
 class OrderSide(Enum):
     """Order side (buy/sell)"""
+
     BUY = True
     SELL = False
 
+
 class TriggerType(Enum):
     """Trigger order types"""
+
     TAKE_PROFIT = "tp"
     STOP_LOSS = "sl"
+
 
 class Order:
     """
     A wrapper class for Hyperliquid exchange order methods that provides a simpler interface.
-    
+
     Reference: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
     """
-    
+
     def __init__(self, exchange: Exchange):
         """
         Initialize the Order wrapper with a Hyperliquid exchange instance.
-        
+
         Args:
             exchange (Exchange): An initialized Hyperliquid exchange instance
         """
@@ -60,7 +68,7 @@ class Order:
         slippage: float = Exchange.DEFAULT_SLIPPAGE,
         reduce_only: bool = False,
         cloid: Optional[Cloid] = None,
-        builder: Optional[BuilderInfo] = None
+        builder: Optional[BuilderInfo] = None,
     ) -> Any:
         """
         Place a market order using asset quantity.
@@ -77,9 +85,7 @@ class Order:
         Returns:
             Exchange response
         """
-        return self.exchange.market_open(
-            asset, side.value, quantity, None, slippage, cloid, builder
-        )
+        return self.exchange.market_open(asset, side.value, quantity, None, slippage, cloid, builder)
 
     def market_order_notional(
         self,
@@ -89,7 +95,7 @@ class Order:
         slippage: float = Exchange.DEFAULT_SLIPPAGE,
         reduce_only: bool = False,
         cloid: Optional[Cloid] = None,
-        builder: Optional[BuilderInfo] = None
+        builder: Optional[BuilderInfo] = None,
     ) -> Any:
         """
         Place a market order using notional amount (USD).
@@ -107,9 +113,7 @@ class Order:
             Exchange response
         """
         quantity = self._calculate_quantity(asset, notional_amount)
-        return self.market_order(
-            asset, side, quantity, slippage, reduce_only, cloid, builder
-        )
+        return self.market_order(asset, side, quantity, slippage, reduce_only, cloid, builder)
 
     def limit_order(
         self,
@@ -120,7 +124,7 @@ class Order:
         tif: TimeInForce = TimeInForce.GTC,
         reduce_only: bool = False,
         cloid: Optional[Cloid] = None,
-        builder: Optional[BuilderInfo] = None
+        builder: Optional[BuilderInfo] = None,
     ) -> Any:
         """
         Place a limit order using asset quantity.
@@ -139,9 +143,7 @@ class Order:
             Exchange response
         """
         order_type = self._create_order_type(tif)
-        return self.exchange.order(
-            asset, side.value, quantity, price, order_type, reduce_only, cloid, builder
-        )
+        return self.exchange.order(asset, side.value, quantity, price, order_type, reduce_only, cloid, builder)
 
     def limit_order_notional(
         self,
@@ -152,7 +154,7 @@ class Order:
         tif: TimeInForce = TimeInForce.GTC,
         reduce_only: bool = False,
         cloid: Optional[Cloid] = None,
-        builder: Optional[BuilderInfo] = None
+        builder: Optional[BuilderInfo] = None,
     ) -> Any:
         """
         Place a limit order using notional amount (USD).
@@ -171,9 +173,7 @@ class Order:
             Exchange response
         """
         quantity = self._calculate_quantity(asset, notional_amount, price)
-        return self.limit_order(
-            asset, side, quantity, price, tif, reduce_only, cloid, builder
-        )
+        return self.limit_order(asset, side, quantity, price, tif, reduce_only, cloid, builder)
 
     def cancel_order(self, asset: str, oid: int) -> Any:
         """Cancel an order by order ID"""
@@ -192,7 +192,7 @@ class Order:
         price: float,
         tif: TimeInForce = TimeInForce.GTC,
         reduce_only: bool = False,
-        cloid: Optional[Cloid] = None
+        cloid: Optional[Cloid] = None,
     ) -> Any:
         """
         Modify an existing order.
@@ -213,7 +213,7 @@ class Order:
         order_type = self._create_order_type(tif)
         return self.exchange.modify_order(
             oid_or_cloid, asset, side.value, quantity, price, order_type, reduce_only, cloid
-        ) 
+        )
 
     def stop_loss(
         self,
@@ -228,7 +228,7 @@ class Order:
     ) -> Any:
         """
         Place a stop loss order.
-        
+
         Args:
             asset: Asset symbol
             side: OrderSide.BUY or OrderSide.SELL
@@ -239,21 +239,12 @@ class Order:
             reduce_only: Whether order reduces position only
             cloid: Optional client order ID
         """
-        order_type = {
-            "trigger": {
-                "triggerPx": trigger_price,
-                "isMarket": is_market,
-                "tpsl": "sl"
-            }
-        }
-        
+        order_type = {"trigger": {"triggerPx": trigger_price, "isMarket": is_market, "tpsl": "sl"}}
+
         # For stop-limit orders, use the limit price, otherwise use trigger price
         exec_price = limit_price if limit_price is not None else trigger_price
-        
-        return self.exchange.order(
-            asset, side.value, quantity, exec_price, 
-            order_type, reduce_only, cloid
-        )
+
+        return self.exchange.order(asset, side.value, quantity, exec_price, order_type, reduce_only, cloid)
 
     def take_profit(
         self,
@@ -268,7 +259,7 @@ class Order:
     ) -> Any:
         """
         Place a take profit order.
-        
+
         Args:
             asset: Asset symbol
             side: OrderSide.BUY or OrderSide.SELL
@@ -279,20 +270,11 @@ class Order:
             reduce_only: Whether order reduces position only
             cloid: Optional client order ID
         """
-        order_type = {
-            "trigger": {
-                "triggerPx": trigger_price,
-                "isMarket": is_market,
-                "tpsl": "tp"
-            }
-        }
-        
+        order_type = {"trigger": {"triggerPx": trigger_price, "isMarket": is_market, "tpsl": "tp"}}
+
         exec_price = limit_price if limit_price is not None else trigger_price
-        
-        return self.exchange.order(
-            asset, side.value, quantity, exec_price, 
-            order_type, reduce_only, cloid
-        )
+
+        return self.exchange.order(asset, side.value, quantity, exec_price, order_type, reduce_only, cloid)
 
     def bracket_order(
         self,
@@ -308,7 +290,7 @@ class Order:
     ) -> List[Any]:
         """
         Place a bracket order (entry + stop loss + take profit).
-        
+
         Args:
             asset: Asset symbol
             side: OrderSide.BUY or OrderSide.SELL
@@ -321,15 +303,12 @@ class Order:
             cloid: Optional client order ID base (will be incremented)
         """
         results = []
-        
+
         # Entry order
         entry_order_type = self._create_order_type(entry_type)
         entry_cloid = Cloid.from_int(int(cloid.to_raw(), 16)) if cloid else None
-        
-        entry = self.exchange.order(
-            asset, side.value, quantity, entry_price,
-            entry_order_type, False, entry_cloid
-        )
+
+        entry = self.exchange.order(asset, side.value, quantity, entry_price, entry_order_type, False, entry_cloid)
         results.append(entry)
 
         # Only place TP/SL if entry order is accepted
@@ -337,18 +316,14 @@ class Order:
             # Stop loss (opposite side of entry)
             sl_cloid = Cloid.from_int(int(entry_cloid.to_raw(), 16) + 1) if entry_cloid else None
             opposite_side = OrderSide.SELL if side == OrderSide.BUY else OrderSide.BUY
-            sl = self.stop_loss(
-                asset, opposite_side, quantity, stop_loss_price,
-                is_market_tp_sl, None, True, sl_cloid
-            )
+            sl = self.stop_loss(asset, opposite_side, quantity, stop_loss_price, is_market_tp_sl, None, True, sl_cloid)
             results.append(sl)
 
             # Take profit (opposite side of entry)
             tp_cloid = Cloid.from_int(int(entry_cloid.to_raw(), 16) + 2) if entry_cloid else None
             tp = self.take_profit(
-                asset, opposite_side, quantity, take_profit_price,
-                is_market_tp_sl, None, True, tp_cloid
+                asset, opposite_side, quantity, take_profit_price, is_market_tp_sl, None, True, tp_cloid
             )
             results.append(tp)
 
-        return results 
+        return results

--- a/order.py
+++ b/order.py
@@ -1,0 +1,354 @@
+from enum import Enum
+from typing import Optional, Union, Dict, Any, List
+
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils.types import BuilderInfo, Cloid
+
+class TimeInForce(Enum):
+    """Time in force options for orders"""
+    GTC = "Gtc"  # Good till cancelled
+    IOC = "Ioc"  # Immediate or cancel
+    ALO = "Alo"  # Add liquidity only (post-only)
+
+class OrderSide(Enum):
+    """Order side (buy/sell)"""
+    BUY = True
+    SELL = False
+
+class TriggerType(Enum):
+    """Trigger order types"""
+    TAKE_PROFIT = "tp"
+    STOP_LOSS = "sl"
+
+class Order:
+    """
+    A wrapper class for Hyperliquid exchange order methods that provides a simpler interface.
+    
+    Reference: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
+    """
+    
+    def __init__(self, exchange: Exchange):
+        """
+        Initialize the Order wrapper with a Hyperliquid exchange instance.
+        
+        Args:
+            exchange (Exchange): An initialized Hyperliquid exchange instance
+        """
+        self.exchange = exchange
+        self.info = exchange.info
+
+    def _get_asset_price(self, asset: str) -> float:
+        """Get current mid price for an asset"""
+        coin = self.info.name_to_coin[asset]
+        return float(self.info.all_mids()[coin])
+
+    def _calculate_quantity(self, asset: str, notional_amount: float, price: Optional[float] = None) -> float:
+        """Calculate asset quantity from notional amount"""
+        if price is None:
+            price = self._get_asset_price(asset)
+        return notional_amount / price
+
+    def _create_order_type(self, tif: TimeInForce) -> Dict:
+        """Create order type dictionary"""
+        return {"limit": {"tif": tif.value}}
+
+    def market_order(
+        self,
+        asset: str,
+        side: OrderSide,
+        quantity: float,
+        slippage: float = Exchange.DEFAULT_SLIPPAGE,
+        reduce_only: bool = False,
+        cloid: Optional[Cloid] = None,
+        builder: Optional[BuilderInfo] = None
+    ) -> Any:
+        """
+        Place a market order using asset quantity.
+
+        Args:
+            asset: Asset symbol (e.g. "ETH", "BTC")
+            side: OrderSide.BUY or OrderSide.SELL
+            quantity: Quantity of asset
+            slippage: Maximum allowed slippage (default 5%)
+            reduce_only: Whether order reduces position only
+            cloid: Optional client order ID
+            builder: Optional builder information
+
+        Returns:
+            Exchange response
+        """
+        return self.exchange.market_open(
+            asset, side.value, quantity, None, slippage, cloid, builder
+        )
+
+    def market_order_notional(
+        self,
+        asset: str,
+        side: OrderSide,
+        notional_amount: float,
+        slippage: float = Exchange.DEFAULT_SLIPPAGE,
+        reduce_only: bool = False,
+        cloid: Optional[Cloid] = None,
+        builder: Optional[BuilderInfo] = None
+    ) -> Any:
+        """
+        Place a market order using notional amount (USD).
+
+        Args:
+            asset: Asset symbol
+            side: OrderSide.BUY or OrderSide.SELL
+            notional_amount: Amount in USD
+            slippage: Maximum allowed slippage (default 5%)
+            reduce_only: Whether order reduces position only
+            cloid: Optional client order ID
+            builder: Optional builder information
+
+        Returns:
+            Exchange response
+        """
+        quantity = self._calculate_quantity(asset, notional_amount)
+        return self.market_order(
+            asset, side, quantity, slippage, reduce_only, cloid, builder
+        )
+
+    def limit_order(
+        self,
+        asset: str,
+        side: OrderSide,
+        quantity: float,
+        price: float,
+        tif: TimeInForce = TimeInForce.GTC,
+        reduce_only: bool = False,
+        cloid: Optional[Cloid] = None,
+        builder: Optional[BuilderInfo] = None
+    ) -> Any:
+        """
+        Place a limit order using asset quantity.
+
+        Args:
+            asset: Asset symbol
+            side: OrderSide.BUY or OrderSide.SELL
+            quantity: Quantity of asset
+            price: Limit price
+            tif: Time in force (GTC/IOC/ALO)
+            reduce_only: Whether order reduces position only
+            cloid: Optional client order ID
+            builder: Optional builder information
+
+        Returns:
+            Exchange response
+        """
+        order_type = self._create_order_type(tif)
+        return self.exchange.order(
+            asset, side.value, quantity, price, order_type, reduce_only, cloid, builder
+        )
+
+    def limit_order_notional(
+        self,
+        asset: str,
+        side: OrderSide,
+        notional_amount: float,
+        price: float,
+        tif: TimeInForce = TimeInForce.GTC,
+        reduce_only: bool = False,
+        cloid: Optional[Cloid] = None,
+        builder: Optional[BuilderInfo] = None
+    ) -> Any:
+        """
+        Place a limit order using notional amount (USD).
+
+        Args:
+            asset: Asset symbol
+            side: OrderSide.BUY or OrderSide.SELL
+            notional_amount: Amount in USD
+            price: Limit price
+            tif: Time in force (GTC/IOC/ALO)
+            reduce_only: Whether order reduces position only
+            cloid: Optional client order ID
+            builder: Optional builder information
+
+        Returns:
+            Exchange response
+        """
+        quantity = self._calculate_quantity(asset, notional_amount, price)
+        return self.limit_order(
+            asset, side, quantity, price, tif, reduce_only, cloid, builder
+        )
+
+    def cancel_order(self, asset: str, oid: int) -> Any:
+        """Cancel an order by order ID"""
+        return self.exchange.cancel(asset, oid)
+
+    def cancel_order_by_cloid(self, asset: str, cloid: Cloid) -> Any:
+        """Cancel an order by client order ID"""
+        return self.exchange.cancel_by_cloid(asset, cloid)
+
+    def modify_order(
+        self,
+        oid_or_cloid: Union[int, Cloid],
+        asset: str,
+        side: OrderSide,
+        quantity: float,
+        price: float,
+        tif: TimeInForce = TimeInForce.GTC,
+        reduce_only: bool = False,
+        cloid: Optional[Cloid] = None
+    ) -> Any:
+        """
+        Modify an existing order.
+
+        Args:
+            oid_or_cloid: Order ID or client order ID to modify
+            asset: Asset symbol
+            side: OrderSide.BUY or OrderSide.SELL
+            quantity: New quantity
+            price: New price
+            tif: Time in force (GTC/IOC/ALO)
+            reduce_only: Whether order reduces position only
+            cloid: Optional new client order ID
+
+        Returns:
+            Exchange response
+        """
+        order_type = self._create_order_type(tif)
+        return self.exchange.modify_order(
+            oid_or_cloid, asset, side.value, quantity, price, order_type, reduce_only, cloid
+        ) 
+
+    def stop_loss(
+        self,
+        asset: str,
+        side: OrderSide,
+        quantity: float,
+        trigger_price: float,
+        is_market: bool = True,
+        limit_price: Optional[float] = None,
+        reduce_only: bool = True,
+        cloid: Optional[Cloid] = None,
+    ) -> Any:
+        """
+        Place a stop loss order.
+        
+        Args:
+            asset: Asset symbol
+            side: OrderSide.BUY or OrderSide.SELL
+            quantity: Quantity of asset
+            trigger_price: Price at which the stop loss triggers
+            is_market: If True, executes as market order when triggered
+            limit_price: Optional limit price for stop-limit orders
+            reduce_only: Whether order reduces position only
+            cloid: Optional client order ID
+        """
+        order_type = {
+            "trigger": {
+                "triggerPx": trigger_price,
+                "isMarket": is_market,
+                "tpsl": "sl"
+            }
+        }
+        
+        # For stop-limit orders, use the limit price, otherwise use trigger price
+        exec_price = limit_price if limit_price is not None else trigger_price
+        
+        return self.exchange.order(
+            asset, side.value, quantity, exec_price, 
+            order_type, reduce_only, cloid
+        )
+
+    def take_profit(
+        self,
+        asset: str,
+        side: OrderSide,
+        quantity: float,
+        trigger_price: float,
+        is_market: bool = True,
+        limit_price: Optional[float] = None,
+        reduce_only: bool = True,
+        cloid: Optional[Cloid] = None,
+    ) -> Any:
+        """
+        Place a take profit order.
+        
+        Args:
+            asset: Asset symbol
+            side: OrderSide.BUY or OrderSide.SELL
+            quantity: Quantity of asset
+            trigger_price: Price at which the take profit triggers
+            is_market: If True, executes as market order when triggered
+            limit_price: Optional limit price for limit orders
+            reduce_only: Whether order reduces position only
+            cloid: Optional client order ID
+        """
+        order_type = {
+            "trigger": {
+                "triggerPx": trigger_price,
+                "isMarket": is_market,
+                "tpsl": "tp"
+            }
+        }
+        
+        exec_price = limit_price if limit_price is not None else trigger_price
+        
+        return self.exchange.order(
+            asset, side.value, quantity, exec_price, 
+            order_type, reduce_only, cloid
+        )
+
+    def bracket_order(
+        self,
+        asset: str,
+        side: OrderSide,
+        quantity: float,
+        entry_price: float,
+        stop_loss_price: float,
+        take_profit_price: float,
+        entry_type: TimeInForce = TimeInForce.GTC,
+        is_market_tp_sl: bool = True,
+        cloid: Optional[Cloid] = None,
+    ) -> List[Any]:
+        """
+        Place a bracket order (entry + stop loss + take profit).
+        
+        Args:
+            asset: Asset symbol
+            side: OrderSide.BUY or OrderSide.SELL
+            quantity: Quantity of asset
+            entry_price: Entry order price
+            stop_loss_price: Stop loss trigger price
+            take_profit_price: Take profit trigger price
+            entry_type: Time in force for entry order
+            is_market_tp_sl: If True, TP/SL execute as market orders
+            cloid: Optional client order ID base (will be incremented)
+        """
+        results = []
+        
+        # Entry order
+        entry_order_type = self._create_order_type(entry_type)
+        entry_cloid = Cloid.from_int(int(cloid.to_raw(), 16)) if cloid else None
+        
+        entry = self.exchange.order(
+            asset, side.value, quantity, entry_price,
+            entry_order_type, False, entry_cloid
+        )
+        results.append(entry)
+
+        # Only place TP/SL if entry order is accepted
+        if entry["status"] == "ok":
+            # Stop loss (opposite side of entry)
+            sl_cloid = Cloid.from_int(int(entry_cloid.to_raw(), 16) + 1) if entry_cloid else None
+            opposite_side = OrderSide.SELL if side == OrderSide.BUY else OrderSide.BUY
+            sl = self.stop_loss(
+                asset, opposite_side, quantity, stop_loss_price,
+                is_market_tp_sl, None, True, sl_cloid
+            )
+            results.append(sl)
+
+            # Take profit (opposite side of entry)
+            tp_cloid = Cloid.from_int(int(entry_cloid.to_raw(), 16) + 2) if entry_cloid else None
+            tp = self.take_profit(
+                asset, opposite_side, quantity, take_profit_price,
+                is_market_tp_sl, None, True, tp_cloid
+            )
+            results.append(tp)
+
+        return results 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,10 +1,12 @@
-import pytest
-from unittest.mock import Mock, patch
 from decimal import Decimal
+from unittest.mock import Mock, patch
+
+import pytest
 
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils.types import Cloid
 from order import Order, OrderSide, TimeInForce, TriggerType
+
 
 @pytest.fixture
 def mock_exchange():
@@ -15,129 +17,84 @@ def mock_exchange():
     exchange.info.all_mids = lambda: {"1": "1800.0", "0": "45000.0"}
     return exchange
 
+
 @pytest.fixture
 def order_wrapper(mock_exchange):
     return Order(mock_exchange)
+
 
 class TestOrderWrapper:
     def test_market_order_buy(self, order_wrapper, mock_exchange):
         """Test market buy order placement"""
         order_wrapper.market_order("ETH", OrderSide.BUY, 1.0)
-        
-        mock_exchange.market_open.assert_called_once_with(
-            "ETH", True, 1.0, None, Exchange.DEFAULT_SLIPPAGE, None, None
-        )
+
+        mock_exchange.market_open.assert_called_once_with("ETH", True, 1.0, None, Exchange.DEFAULT_SLIPPAGE, None, None)
 
     def test_market_order_sell(self, order_wrapper, mock_exchange):
         """Test market sell order placement"""
         order_wrapper.market_order("ETH", OrderSide.SELL, 1.0, slippage=0.01)
-        
-        mock_exchange.market_open.assert_called_once_with(
-            "ETH", False, 1.0, None, 0.01, None, None
-        )
+
+        mock_exchange.market_open.assert_called_once_with("ETH", False, 1.0, None, 0.01, None, None)
 
     def test_market_order_notional_buy(self, order_wrapper, mock_exchange):
         """Test market buy order with notional amount"""
         # $1800 worth of ETH at current price of $1800 = 1.0 ETH
         order_wrapper.market_order_notional("ETH", OrderSide.BUY, 1800)
-        
-        mock_exchange.market_open.assert_called_once_with(
-            "ETH", True, 1.0, None, Exchange.DEFAULT_SLIPPAGE, None, None
-        )
+
+        mock_exchange.market_open.assert_called_once_with("ETH", True, 1.0, None, Exchange.DEFAULT_SLIPPAGE, None, None)
 
     def test_limit_order_buy(self, order_wrapper, mock_exchange):
         """Test limit buy order placement"""
-        order_wrapper.limit_order(
-            "ETH", 
-            OrderSide.BUY, 
-            1.0, 
-            1750.0, 
-            TimeInForce.GTC
-        )
-        
+        order_wrapper.limit_order("ETH", OrderSide.BUY, 1.0, 1750.0, TimeInForce.GTC)
+
         mock_exchange.order.assert_called_once_with(
-            "ETH", True, 1.0, 1750.0, 
-            {"limit": {"tif": "Gtc"}}, False, None, None
+            "ETH", True, 1.0, 1750.0, {"limit": {"tif": "Gtc"}}, False, None, None
         )
 
     def test_limit_order_sell_post_only(self, order_wrapper, mock_exchange):
         """Test post-only limit sell order"""
-        order_wrapper.limit_order(
-            "ETH",
-            OrderSide.SELL,
-            1.0,
-            1850.0,
-            TimeInForce.ALO
-        )
-        
+        order_wrapper.limit_order("ETH", OrderSide.SELL, 1.0, 1850.0, TimeInForce.ALO)
+
         mock_exchange.order.assert_called_once_with(
-            "ETH", False, 1.0, 1850.0,
-            {"limit": {"tif": "Alo"}}, False, None, None
+            "ETH", False, 1.0, 1850.0, {"limit": {"tif": "Alo"}}, False, None, None
         )
 
     def test_stop_loss_market(self, order_wrapper, mock_exchange):
         """Test market stop loss order"""
-        order_wrapper.stop_loss(
-            "ETH",
-            OrderSide.SELL,
-            1.0,
-            1750.0,
-            is_market=True
-        )
-        
+        order_wrapper.stop_loss("ETH", OrderSide.SELL, 1.0, 1750.0, is_market=True)
+
         mock_exchange.order.assert_called_once_with(
-            "ETH", False, 1.0, 1750.0,
-            {"trigger": {"triggerPx": 1750.0, "isMarket": True, "tpsl": "sl"}},
-            True, None
+            "ETH", False, 1.0, 1750.0, {"trigger": {"triggerPx": 1750.0, "isMarket": True, "tpsl": "sl"}}, True, None
         )
 
     def test_take_profit_limit(self, order_wrapper, mock_exchange):
         """Test limit take profit order"""
-        order_wrapper.take_profit(
-            "ETH",
-            OrderSide.SELL,
-            1.0,
-            1900.0,
-            is_market=False,
-            limit_price=1895.0
-        )
-        
+        order_wrapper.take_profit("ETH", OrderSide.SELL, 1.0, 1900.0, is_market=False, limit_price=1895.0)
+
         mock_exchange.order.assert_called_once_with(
-            "ETH", False, 1.0, 1895.0,
-            {"trigger": {"triggerPx": 1900.0, "isMarket": False, "tpsl": "tp"}},
-            True, None
+            "ETH", False, 1.0, 1895.0, {"trigger": {"triggerPx": 1900.0, "isMarket": False, "tpsl": "tp"}}, True, None
         )
 
     def test_bracket_order(self, order_wrapper, mock_exchange):
         """Test bracket order placement"""
         mock_exchange.order.return_value = {"status": "ok"}
         cloid = Cloid.from_int(1)
-        
-        order_wrapper.bracket_order(
-            "ETH",
-            OrderSide.BUY,
-            1.0,
-            1800.0,
-            1750.0,
-            1850.0,
-            TimeInForce.GTC,
-            True,
-            cloid
-        )
-        
+
+        order_wrapper.bracket_order("ETH", OrderSide.BUY, 1.0, 1800.0, 1750.0, 1850.0, TimeInForce.GTC, True, cloid)
+
         # Should place 3 orders: entry, stop loss, and take profit
         assert mock_exchange.order.call_count == 3
-        
+
         calls = mock_exchange.order.call_args_list
-        
+
         # Verify entry order
         assert calls[0][0][0:4] == ("ETH", True, 1.0, 1800.0)
         assert calls[0][0][4] == {"limit": {"tif": "Gtc"}}
-        
+
         # Verify stop loss order
         assert calls[1][0][0:4] == ("ETH", False, 1.0, 1750.0)
         assert calls[1][0][4]["trigger"]["tpsl"] == "sl"
-        
+
         # Verify take profit order
         assert calls[2][0][0:4] == ("ETH", False, 1.0, 1850.0)
         assert calls[2][0][4]["trigger"]["tpsl"] == "tp"
@@ -145,18 +102,10 @@ class TestOrderWrapper:
     def test_modify_order(self, order_wrapper, mock_exchange):
         """Test order modification"""
         oid = 12345
-        order_wrapper.modify_order(
-            oid,
-            "ETH",
-            OrderSide.BUY,
-            1.0,
-            1800.0,
-            TimeInForce.GTC
-        )
-        
+        order_wrapper.modify_order(oid, "ETH", OrderSide.BUY, 1.0, 1800.0, TimeInForce.GTC)
+
         mock_exchange.modify_order.assert_called_once_with(
-            oid, "ETH", True, 1.0, 1800.0,
-            {"limit": {"tif": "Gtc"}}, False, None
+            oid, "ETH", True, 1.0, 1800.0, {"limit": {"tif": "Gtc"}}, False, None
         )
 
     def test_cancel_order(self, order_wrapper, mock_exchange):
@@ -174,16 +123,13 @@ class TestOrderWrapper:
         """Test internal price calculation methods"""
         eth_price = order_wrapper._get_asset_price("ETH")
         assert eth_price == 1800.0
-        
+
         quantity = order_wrapper._calculate_quantity("ETH", 1800)
         assert quantity == 1.0
 
-    @pytest.mark.parametrize("side,expected", [
-        (OrderSide.BUY, True),
-        (OrderSide.SELL, False)
-    ])
+    @pytest.mark.parametrize("side,expected", [(OrderSide.BUY, True), (OrderSide.SELL, False)])
     def test_order_side_conversion(self, order_wrapper, mock_exchange, side, expected):
         """Test order side enum conversion"""
         order_wrapper.market_order("ETH", side, 1.0)
         args = mock_exchange.market_open.call_args[0]
-        assert args[1] == expected 
+        assert args[1] == expected

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,0 +1,189 @@
+import pytest
+from unittest.mock import Mock, patch
+from decimal import Decimal
+
+from hyperliquid.exchange import Exchange
+from hyperliquid.utils.types import Cloid
+from order import Order, OrderSide, TimeInForce, TriggerType
+
+@pytest.fixture
+def mock_exchange():
+    exchange = Mock(spec=Exchange)
+    # Mock the info attribute and its methods
+    exchange.info = Mock()
+    exchange.info.name_to_coin = {"ETH": "1", "BTC": "0"}
+    exchange.info.all_mids = lambda: {"1": "1800.0", "0": "45000.0"}
+    return exchange
+
+@pytest.fixture
+def order_wrapper(mock_exchange):
+    return Order(mock_exchange)
+
+class TestOrderWrapper:
+    def test_market_order_buy(self, order_wrapper, mock_exchange):
+        """Test market buy order placement"""
+        order_wrapper.market_order("ETH", OrderSide.BUY, 1.0)
+        
+        mock_exchange.market_open.assert_called_once_with(
+            "ETH", True, 1.0, None, Exchange.DEFAULT_SLIPPAGE, None, None
+        )
+
+    def test_market_order_sell(self, order_wrapper, mock_exchange):
+        """Test market sell order placement"""
+        order_wrapper.market_order("ETH", OrderSide.SELL, 1.0, slippage=0.01)
+        
+        mock_exchange.market_open.assert_called_once_with(
+            "ETH", False, 1.0, None, 0.01, None, None
+        )
+
+    def test_market_order_notional_buy(self, order_wrapper, mock_exchange):
+        """Test market buy order with notional amount"""
+        # $1800 worth of ETH at current price of $1800 = 1.0 ETH
+        order_wrapper.market_order_notional("ETH", OrderSide.BUY, 1800)
+        
+        mock_exchange.market_open.assert_called_once_with(
+            "ETH", True, 1.0, None, Exchange.DEFAULT_SLIPPAGE, None, None
+        )
+
+    def test_limit_order_buy(self, order_wrapper, mock_exchange):
+        """Test limit buy order placement"""
+        order_wrapper.limit_order(
+            "ETH", 
+            OrderSide.BUY, 
+            1.0, 
+            1750.0, 
+            TimeInForce.GTC
+        )
+        
+        mock_exchange.order.assert_called_once_with(
+            "ETH", True, 1.0, 1750.0, 
+            {"limit": {"tif": "Gtc"}}, False, None, None
+        )
+
+    def test_limit_order_sell_post_only(self, order_wrapper, mock_exchange):
+        """Test post-only limit sell order"""
+        order_wrapper.limit_order(
+            "ETH",
+            OrderSide.SELL,
+            1.0,
+            1850.0,
+            TimeInForce.ALO
+        )
+        
+        mock_exchange.order.assert_called_once_with(
+            "ETH", False, 1.0, 1850.0,
+            {"limit": {"tif": "Alo"}}, False, None, None
+        )
+
+    def test_stop_loss_market(self, order_wrapper, mock_exchange):
+        """Test market stop loss order"""
+        order_wrapper.stop_loss(
+            "ETH",
+            OrderSide.SELL,
+            1.0,
+            1750.0,
+            is_market=True
+        )
+        
+        mock_exchange.order.assert_called_once_with(
+            "ETH", False, 1.0, 1750.0,
+            {"trigger": {"triggerPx": 1750.0, "isMarket": True, "tpsl": "sl"}},
+            True, None
+        )
+
+    def test_take_profit_limit(self, order_wrapper, mock_exchange):
+        """Test limit take profit order"""
+        order_wrapper.take_profit(
+            "ETH",
+            OrderSide.SELL,
+            1.0,
+            1900.0,
+            is_market=False,
+            limit_price=1895.0
+        )
+        
+        mock_exchange.order.assert_called_once_with(
+            "ETH", False, 1.0, 1895.0,
+            {"trigger": {"triggerPx": 1900.0, "isMarket": False, "tpsl": "tp"}},
+            True, None
+        )
+
+    def test_bracket_order(self, order_wrapper, mock_exchange):
+        """Test bracket order placement"""
+        mock_exchange.order.return_value = {"status": "ok"}
+        cloid = Cloid.from_int(1)
+        
+        order_wrapper.bracket_order(
+            "ETH",
+            OrderSide.BUY,
+            1.0,
+            1800.0,
+            1750.0,
+            1850.0,
+            TimeInForce.GTC,
+            True,
+            cloid
+        )
+        
+        # Should place 3 orders: entry, stop loss, and take profit
+        assert mock_exchange.order.call_count == 3
+        
+        calls = mock_exchange.order.call_args_list
+        
+        # Verify entry order
+        assert calls[0][0][0:4] == ("ETH", True, 1.0, 1800.0)
+        assert calls[0][0][4] == {"limit": {"tif": "Gtc"}}
+        
+        # Verify stop loss order
+        assert calls[1][0][0:4] == ("ETH", False, 1.0, 1750.0)
+        assert calls[1][0][4]["trigger"]["tpsl"] == "sl"
+        
+        # Verify take profit order
+        assert calls[2][0][0:4] == ("ETH", False, 1.0, 1850.0)
+        assert calls[2][0][4]["trigger"]["tpsl"] == "tp"
+
+    def test_modify_order(self, order_wrapper, mock_exchange):
+        """Test order modification"""
+        oid = 12345
+        order_wrapper.modify_order(
+            oid,
+            "ETH",
+            OrderSide.BUY,
+            1.0,
+            1800.0,
+            TimeInForce.GTC
+        )
+        
+        mock_exchange.modify_order.assert_called_once_with(
+            oid, "ETH", True, 1.0, 1800.0,
+            {"limit": {"tif": "Gtc"}}, False, None
+        )
+
+    def test_cancel_order(self, order_wrapper, mock_exchange):
+        """Test order cancellation"""
+        order_wrapper.cancel_order("ETH", 12345)
+        mock_exchange.cancel.assert_called_once_with("ETH", 12345)
+
+    def test_cancel_order_by_cloid(self, order_wrapper, mock_exchange):
+        """Test order cancellation by CLOID"""
+        cloid = Cloid.from_int(1)
+        order_wrapper.cancel_order_by_cloid("ETH", cloid)
+        mock_exchange.cancel_by_cloid.assert_called_once_with("ETH", cloid)
+
+    def test_price_calculation(self, order_wrapper):
+        """Test internal price calculation methods"""
+        eth_price = order_wrapper._get_asset_price("ETH")
+        assert eth_price == 1800.0
+        
+        quantity = order_wrapper._calculate_quantity("ETH", 1800)
+        assert quantity == 1.0
+
+    @pytest.mark.parametrize("side,expected", [
+        (OrderSide.BUY, True),
+        (OrderSide.SELL, False)
+    ])
+    def test_order_side_conversion(self, order_wrapper, mock_exchange, side, expected):
+        """Test order side enum conversion"""
+        order_wrapper.market_order("ETH", side, 1.0)
+        args = mock_exchange.market_open.call_args[0]
+        assert args[1] == expected 


### PR DESCRIPTION
# Order Wrapper Implementation

## Overview
This PR introduces a new `Order` wrapper class that simplifies the interaction with Hyperliquid's exchange model. It makes it easy to use declarative interfaces to do market/limit/stop/bracket/tpsl orders

## Files Changed
- `order.py`: New wrapper class implementation
- `tests/test_order.py`: Comprehensive test suite
- `examples/order_examples.py`: Usage examples and patterns

## Example Usage

Full example added to `examples/order_examples`

```python


from order import Order, OrderSide, TimeInForce

# Setup exchange connection
_, _, exchange = example_utils.setup(constants.TESTNET_API_URL, skip_ws=True)

# Create order wrapper
order = Order(exchange)

# Example 1: Simple Market Orders
print("\n=== Market Order Examples ===")

# Market buy 0.1 ETH
result = order.market_order(asset="ETH", side=OrderSide.BUY, quantity=0.1, slippage=0.01)  # 1% max slippage
print(f"Market Buy Result: {result}")

# Market sell $1000 worth of BTC
result = order.market_order_notional(asset="BTC", side=OrderSide.SELL, notional_amount=1000)  # USD amount
print(f"Market Sell (Notional) Result: {result}")

# Example 2: Limit Orders
print("\n=== Limit Order Examples ===")

# Limit buy 0.1 ETH at $1800
result = order.limit_order(
    asset="ETH", side=OrderSide.BUY, quantity=0.1, price=1800, tif=TimeInForce.GTC  # Good till cancelled
)
print(f"Limit Buy Result: {result}")

# Post-only limit sell $2000 worth of ETH at $1900
result = order.limit_order_notional(
    asset="ETH",
    side=OrderSide.SELL,
    notional_amount=2000,
    price=1900,
    tif=TimeInForce.ALO,  # Add liquidity only (post-only)
)
print(f"Post-only Limit Sell Result: {result}")

```

## Testing

All new functionality is covered by unit tests. Run the test suite with:

```bash
poetry run pytest tests/test_order.py
```