### PR TITLE
Fix ci workflow: Stop producing the coverage badge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ formatting: codestyle
 #* Linting
 test:
 	poetry run pytest -c pyproject.toml tests/
-	poetry run coverage-badge -o assets/images/coverage.svg -f
 
 check-codestyle:
 	poetry run isort --diff --check-only --settings-path pyproject.toml ./


### PR DESCRIPTION
This PR fixes the automated Github test workflow introduced in https://github.com/hyperliquid-dex/hyperliquid-python-sdk/pull/113 ... The failure wasn't obvious as Github actions weren't activated before.

The error can be seen e.g. in this run https://github.com/hyperliquid-dex/hyperliquid-python-sdk/actions/runs/12834171538/job/35790880179

The fix is to not generated the coverage.svg badge as that is anyways currently not shown in the README anymore.

The PR now tests itself :) 

Update: Seems like Action runs still need an approval ... the PR indicates below: "1 workflow awaiting approval" ... that can be configured in the repo settings: Like "Require approval for first-time contributors" or "Require approval for all external contributors" ...  in https://github.com/hyperliquid-dex/hyperliquid-python-sdk/settings/actions