### PR TITLE
feat: Add order grouping support

### DIFF
--- a/hyperliquid/exchange.py
+++ b/hyperliquid/exchange.py
@@ -94,7 +94,6 @@ class Exchange(API):
         reduce_only: bool = False,
         cloid: Optional[Cloid] = None,
         builder: Optional[BuilderInfo] = None,
-        grouping: Grouping = "na",
     ) -> Any:
         order: OrderRequest = {
             "coin": name,
@@ -106,7 +105,7 @@ class Exchange(API):
         }
         if cloid:
             order["cloid"] = cloid
-        return self.bulk_orders([order], builder, grouping)
+        return self.bulk_orders([order], builder)
 
     def bulk_orders(
         self,

--- a/hyperliquid/exchange.py
+++ b/hyperliquid/exchange.py
@@ -11,6 +11,7 @@ from hyperliquid.utils.constants import MAINNET_API_URL
 from hyperliquid.utils.signing import (
     CancelByCloidRequest,
     CancelRequest,
+    Grouping,
     ModifyRequest,
     OidOrCloid,
     OrderRequest,
@@ -93,6 +94,7 @@ class Exchange(API):
         reduce_only: bool = False,
         cloid: Optional[Cloid] = None,
         builder: Optional[BuilderInfo] = None,
+        grouping: Grouping = "na",
     ) -> Any:
         order: OrderRequest = {
             "coin": name,
@@ -104,9 +106,14 @@ class Exchange(API):
         }
         if cloid:
             order["cloid"] = cloid
-        return self.bulk_orders([order], builder)
+        return self.bulk_orders([order], builder, grouping)
 
-    def bulk_orders(self, order_requests: List[OrderRequest], builder: Optional[BuilderInfo] = None) -> Any:
+    def bulk_orders(
+        self,
+        order_requests: List[OrderRequest],
+        builder: Optional[BuilderInfo] = None,
+        grouping: Grouping = "na",
+    ) -> Any:
         order_wires: List[OrderWire] = [
             order_request_to_order_wire(order, self.info.name_to_asset(order["coin"])) for order in order_requests
         ]
@@ -114,7 +121,7 @@ class Exchange(API):
 
         if builder:
             builder["b"] = builder["b"].lower()
-        order_action = order_wires_to_order_action(order_wires, builder)
+        order_action = order_wires_to_order_action(order_wires, builder, grouping)
 
         signature = sign_l1_action(
             self.wallet,

--- a/hyperliquid/utils/signing.py
+++ b/hyperliquid/utils/signing.py
@@ -407,11 +407,11 @@ def order_request_to_order_wire(order: OrderRequest, asset: int) -> OrderWire:
     return order_wire
 
 
-def order_wires_to_order_action(order_wires, builder=None, grouping:Grouping="na"):
+def order_wires_to_order_action(order_wires, builder=None, grouping: Grouping="na"):
     action = {
         "type": "order",
         "orders": order_wires,
-        "grouping": "na",
+        "grouping": grouping,
     }
     if builder:
         action["builder"] = builder

--- a/hyperliquid/utils/signing.py
+++ b/hyperliquid/utils/signing.py
@@ -407,7 +407,7 @@ def order_request_to_order_wire(order: OrderRequest, asset: int) -> OrderWire:
     return order_wire
 
 
-def order_wires_to_order_action(order_wires, builder=None):
+def order_wires_to_order_action(order_wires, builder=None, grouping:Grouping="na"):
     action = {
         "type": "order",
         "orders": order_wires,


### PR DESCRIPTION
Add support for order grouping to improve take-profit/stop-loss order visualization on the Hyperliquid website. When orders are grouped, their TP/SL orders will be visually linked together in the UI, making it easier to track related orders.

- Add optional grouping parameter to Exchange.order() with default value "na"
- Pass grouping parameter through to bulk_orders()
- Update order_wires_to_order_action() to include grouping parameter
- Maintain backwards compatibility by defaulting to "na" grouping