### PR TITLE
fix ping_sender is blocked by ws.run_forever()

### DIFF
--- a/hyperliquid/websocket_manager.py
+++ b/hyperliquid/websocket_manager.py
@@ -75,8 +75,8 @@ class WebsocketManager(threading.Thread):
         self.stop_event = threading.Event()
 
     def run(self):
-        self.ws.run_forever()
         self.ping_sender.start()
+        self.ws.run_forever()
 
     def send_ping(self):
         while not self.stop_event.wait(50):


### PR DESCRIPTION
The ws thread always will be killed after 1 minute because there's no heartbeat that is sent.
The cause is ws.run_forever() blocks ping_sender.