### PR TITLE
fix(websocket_manager): fix disconnect, on_closed mapped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "hyperliquid-python-sdk"
-version = "0.10.1"
+version = "0.10.2"
 description = "SDK for Hyperliquid API trading with Python."
 readme = "README.md"
 authors = ["Hyperliquid <hello@hyperliquid.xyz>"]


### PR DESCRIPTION
Previously, when the connection to the remote host was lost (e.g., "ERROR:websocket:Connection to remote host was lost. - goodbye"), the WebSocket thread kept running without reconnecting, leaving the system in an inconsistent state.

Now, when the connection is closed, on_close triggers self.stop(), ensuring that the WebSocket thread properly stops and can be restarted if needed.
I originally had issues in my worker where this error would pop (not explicity handled) but the thread kept running.