### PR TITLE
chore(signing): Update to use sign typed data instead of sign message

### DIFF
--- a/hyperliquid/utils/signing.py
+++ b/hyperliquid/utils/signing.py
@@ -392,8 +392,7 @@ def sign_token_delegate_action(wallet, action, is_mainnet):
 
 
 def sign_inner(wallet, data):
-    structured_data = encode_typed_data(full_message=data)
-    signed = wallet.sign_message(structured_data)
+    signed = wallet.sign_typed_data(**data)
     return {"r": to_hex(signed["r"]), "s": to_hex(signed["s"]), "v": signed["v"]}
 
 

--- a/hyperliquid/utils/signing.py
+++ b/hyperliquid/utils/signing.py
@@ -392,7 +392,7 @@ def sign_token_delegate_action(wallet, action, is_mainnet):
 
 
 def sign_inner(wallet, data):
-    signed = wallet.sign_typed_data(**data)
+    signed = wallet.sign_typed_data(full_message=data)
     return {"r": to_hex(signed["r"]), "s": to_hex(signed["s"]), "v": signed["v"]}
 
 


### PR DESCRIPTION
Update the underlying signing logic to use sign typed data from the wallet -

This allows for wallets that don’t support type 0x00 messages via sign_message to still be used by the SDK
![CleanShot 2025-05-07 at 18 59 10@2x](https://github.com/user-attachments/assets/c03abd6b-fd5c-48bc-a737-804fce84c6ab)
