### PR TITLE
add multisig cDeposit example

### DIFF
--- a/examples/multi_sig_cdeposit.py
+++ b/examples/multi_sig_cdeposit.py
@@ -13,7 +13,7 @@ def main():
     # Address of the multi-sig user that the action will be executed for
     # Executing the action requires at least the specified threshold of signatures
     # required for that multi-sig user
-    multi_sig_user = "0xfBfd36dFc2f5b1b82cCd33D695568f5Ca0792A3F"
+    multi_sig_user = "0x0000000000000000000000000000000000000005"
 
     timestamp = get_timestamp_ms()
 

--- a/examples/multi_sig_cdeposit.py
+++ b/examples/multi_sig_cdeposit.py
@@ -1,0 +1,51 @@
+import example_utils
+
+from hyperliquid.utils import constants
+from hyperliquid.utils.signing import CDEPOSIT_SIGN_TYPES, get_timestamp_ms, sign_multi_sig_user_signed_action_payload
+
+
+def main():
+    address, info, exchange = example_utils.setup(constants.TESTNET_API_URL, skip_ws=True)
+    multi_sig_wallets = example_utils.setup_multi_sig_wallets()
+
+    # The outer signer is required to be an authorized user or an agent of the authorized user of the multi-sig user.
+
+    # Address of the multi-sig user that the action will be executed for
+    # Executing the action requires at least the specified threshold of signatures
+    # required for that multi-sig user
+    multi_sig_user = "0xfBfd36dFc2f5b1b82cCd33D695568f5Ca0792A3F"
+
+    timestamp = get_timestamp_ms()
+
+    # Define the multi-sig inner action - in this case, transfer HYPE into staking balance.
+    action = {
+        "type": "cDeposit",
+        "signatureChainId": "0x66eee",
+        "hyperliquidChain": "Testnet",
+        "wei": 100000000,
+        "nonce": timestamp,
+    }
+    signatures = []
+
+    # Collect signatures from each wallet in multi_sig_wallets. Each wallet must belong to a user.
+    for wallet in multi_sig_wallets:
+        # Sign the action with each wallet
+        signature = sign_multi_sig_user_signed_action_payload(
+            wallet,
+            action,
+            exchange.base_url == constants.MAINNET_API_URL,
+            CDEPOSIT_SIGN_TYPES,
+            "HyperliquidTransaction:CDeposit",
+            multi_sig_user,
+            address,
+        )
+        signatures.append(signature)
+
+    # Execute the multi-sig action with all collected signatures
+    # This will only succeed if enough valid signatures are provided
+    multi_sig_result = exchange.multi_sig(multi_sig_user, action, signatures, timestamp)
+    print(multi_sig_result)
+
+
+if __name__ == "__main__":
+    main()

--- a/hyperliquid/utils/signing.py
+++ b/hyperliquid/utils/signing.py
@@ -124,6 +124,11 @@ MULTI_SIG_ENVELOPE_SIGN_TYPES = [
     {"name": "nonce", "type": "uint64"},
 ]
 
+CDEPOSIT_SIGN_TYPES = [
+    {"name": "hyperliquidChain", "type": "string"},
+    {"name": "wei", "type": "uint64"},
+    {"name": "nonce", "type": "uint64"},
+]
 
 def order_type_to_wire(order_type: OrderType) -> OrderTypeWire:
     if "limit" in order_type:


### PR DESCRIPTION
Add an example for calling [cDeposit ](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#deposit-into-staking) for a multisig.

This change also adds CDEPOSIT_SIGN_TYPES into `signing.py`

Tested locally and confirmed `Status 200` and 1 HYPE was transferred to staking balance for the multisig.