### PR TITLE
fix: bump eth-account minimum version to >=0.13.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [  #! Update me
 [tool.poetry.dependencies]
 python = "^3.9"
 eth-utils = ">=2.1.0,<6.0.0"
-eth-account = ">=0.10.0,<0.14.0"
+eth-account = ">=0.13.5,<0.14.0"
 websocket-client = "^1.5.1"
 requests = "^2.31.0"
 msgpack = "^1.0.5"


### PR DESCRIPTION
# Summary
The Hyperliquid client expects `LocalAccount.sign_typed_data` (EIP-712) to exist, but older eth-account releases (e.g. 0.10.x) do not expose that method. As a result, calls to `sign_l1_action` fail with:

`AttributeError: 'LocalAccount' object has no attribute 'sign_typed_data'`

Where the error occured:
```bash
  File "/app/.venv/lib/python3.12/site-packages/hyperliquid/utils/signing.py", line 216, in sign_l1_action
    return sign_inner(wallet, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/hyperliquid/utils/signing.py", line 395, in sign_inner
    signed = wallet.sign_typed_data(full_message=data)
             ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'LocalAccount' object has no attribute 'sign_typed_data'
```

Bump the minimum eth-account version so that EIP-712 signing is guaranteed to work.

## Changes
In `pyproject.toml`, replaced:

```toml
- eth-account = ">=0.10.0,<0.14.0"
+ eth-account = ">=0.13.5,<0.14.0"
```

## Rationale
Versions of eth-account prior to 0.13.5 lack the `LocalAccount.sign_typed_data` method. Hyperliquid’s `sign_l1_action` calls `wallet.sign_typed_data(...)` under the hood, so we must require a release that implements EIP-712 “typed data” signing. Pinning `eth-account >=0.13.5` ensures compatibility without breaking other dependencies.

## Testing
Opened a Python REPL (using the locked environment):
1. Then verified if older version contains the `sign_typed_data` method, which is did not:
```bash
>>> from eth_account import Account
>>> acct = Account.create()
>>> hasattr(acct, "sign_typed_data")
False
>>> dir(acct)
['__abstractmethods__', '__bytes__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slots__', '__str__', '__subclasshook__', '__weakref__', '_abc_impl', '_address', '_key_obj', '_private_key', '_publicapi', 'address', 'encrypt', 'key', 'signHash', 'signTransaction', 'sign_message', 'sign_transaction']
```

2. Checked against the [Latest Client Version](https://github.com/ethereum/eth-account/blob/main/eth_account/signers/local.py#L137) after updating

3. Re-tried and confirmed that it now contained the method:
```bash
>>> from eth_account import Account
>>> acct = Account.create()
>>> hasattr(acct, "sign_typed_data")
True
```


Please let me know if any modifications are needed.