### PR TITLE
correct documentation comments. max_gas in spot deploy is in HYPE.

### DIFF
--- a/examples/spot_deploy.py
+++ b/examples/spot_deploy.py
@@ -24,7 +24,7 @@ def main():
     #
     # Takes part in the spot deploy auction and if successful, registers token "TEST0"
     # with sz_decimals 2 and wei_decimals 8.
-    # The max gas is $1M USDC and represents the max amount to be paid for the spot deploy auction.
+    # The max gas is 10,000 HYPE and represents the max amount to be paid for the spot deploy auction.
     register_token_result = exchange.spot_deploy_register_token("TEST0", 2, 8, 1000000000000, "Test token example")
     print(register_token_result)
     # If registration is successful, a token index will be returned. This token index is required for


### PR DESCRIPTION
correct documentation comments in spot_deploy. max_gas in spot deploy is in terms of HYPE, not in terms of USDC, which is incorrectly stated in the doc comments.

I confirmed this by going to `https://app.hyperliquid-testnet.xyz/deploySpot`, and trying to buy an auction at the current price. The price I of the auction at that time was 2935.97839953 HYPE. the action sent in the api call was
```
{
    "action": {
        "registerToken2": {
            "fullName": "dede",
            "maxGas": 293597839953,
            "spec": {
                "name": "DEDE",
                "szDecimals": 2,
                "weiDecimals": 8
            }
        },
        "type": "spotDeploy"
    }
}
```

so maxGas is in terms of HYPE. not in terms of USDC.