### PR TITLE
feat(examples): option to derive account from an encrypted keystore

### DIFF
--- a/examples/config.json.example
+++ b/examples/config.json.example
@@ -4,11 +4,14 @@
         Fill in your secret key e.g. 0x0000000000000000000000000000000000000000000000000000000000000000
         If you are using an Agent/API Wallet you MUST also specify the public address of your account, not the
         address of the Agent/API Wallet.
-        Otherwise, feel free to leave it blank and it will be automatically derived from the secret key.
+        Otherwise, feel free to leave it blank and it will be automatically derived from the secret key. Alternatively, 
+        you can specify a local `keystore_path` which will prompt you for the keystore password interactively. 
+        Note: If both `secret_key` and `keystore_path` are provided, the keystore will take precedence.
 
         You can also populate the "multi_sig" section with the secret keys of the authorized user wallets that you
         wish to sign multi-sig actions for.
     ",
+    "keystore_path": "",
     "secret_key": "",
     "account_address": "",
     "multi_sig": {

--- a/examples/config.json.example
+++ b/examples/config.json.example
@@ -6,7 +6,7 @@
         address of the Agent/API Wallet.
         Otherwise, feel free to leave it blank and it will be automatically derived from the secret key. Alternatively, 
         you can specify a local `keystore_path` which will prompt you for the keystore password interactively. 
-        Note: If both `secret_key` and `keystore_path` are provided, the keystore will take precedence.
+        Note: If both `secret_key` and `keystore_path` are provided, the `secret_key` will take precedence.
 
         You can also populate the "multi_sig" section with the secret keys of the authorized user wallets that you
         wish to sign multi-sig actions for.

--- a/examples/example_utils.py
+++ b/examples/example_utils.py
@@ -13,8 +13,7 @@ def setup(base_url=None, skip_ws=False, perp_dexs=None):
     config_path = os.path.join(os.path.dirname(__file__), "config.json")
     with open(config_path) as f:
         config = json.load(f)
-    secret_key = get_secret_key(config)
-    account: LocalAccount = eth_account.Account.from_key(secret_key)
+    account: LocalAccount = eth_account.Account.from_key(get_secret_key(config))
     address = config["account_address"]
     if address == "":
         address = account.address

--- a/examples/example_utils.py
+++ b/examples/example_utils.py
@@ -26,9 +26,9 @@ def setup(base_url=None, skip_ws=False, perp_dexs=None):
     exchange = Exchange(account, base_url, account_address=address, perp_dexs=perp_dexs)
     return address, info, exchange
 
+
 def create_account(config):
     if config["keystore_path"]:
-        print("Using keystore to create account...")
         keystore_path = config["keystore_path"]
         keystore_path = os.path.expanduser(keystore_path)
         if not os.path.isabs(keystore_path):

--- a/examples/example_utils.py
+++ b/examples/example_utils.py
@@ -1,6 +1,6 @@
+import getpass
 import json
 import os
-import getpass
 
 import eth_account
 from eth_account.signers.local import LocalAccount
@@ -28,6 +28,7 @@ def setup(base_url=None, skip_ws=False, perp_dexs=None):
 
 
 def create_account(config):
+    account: LocalAccount
     if config["keystore_path"]:
         keystore_path = config["keystore_path"]
         keystore_path = os.path.expanduser(keystore_path)
@@ -41,9 +42,9 @@ def create_account(config):
             keystore = json.load(f)
         password = getpass.getpass("Enter keystore password: ")
         private_key = eth_account.Account.decrypt(keystore, password)
-        account: LocalAccount = eth_account.Account.from_key(private_key)
+        account = eth_account.Account.from_key(private_key)
     else:
-        account: LocalAccount = eth_account.Account.from_key(config["secret_key"])
+        account = eth_account.Account.from_key(config["secret_key"])
     address = config["account_address"]
     if address == "":
         address = account.address


### PR DESCRIPTION
Adds optional ability to derive a `LocalAccount` to use within the provided examples from a local encrypted keystore.

Currently, the `LocalAccount` within `example_utils.py` is created off a provided secret key- but I think it's reasonable to assume that some devs will have secret keys within a keystore that they'd like to use instead. For instance, Foundry users might have keys stored within the Foundry default dir of `~/.foundry/keystores/<NAME>`.  

These changes provide the ability for devs to specify a path to a keystore in their `config.json`. If they do so, the `LocalAccount` will be derived from here, rather than the secret key. 