### PR TITLE
Add spotDeployState to Info class

### DIFF
--- a/hyperliquid/info.py
+++ b/hyperliquid/info.py
@@ -611,7 +611,7 @@ class Info(API):
 
     def query_perp_deploy_auction_status(self) -> Any:
         return self.post("/info", {"type": "perpDeployAuctionStatus"})
-    
+
     def query_spot_deploy_auction_status(self, user: str) -> Any:
         return self.post("/info", {"type": "spotDeployState", "user": user})
 


### PR DESCRIPTION
The method [`spotDeployState`](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/spot#retrieve-information-about-the-spot-deploy-auction) doesn't exist in SDK.

Similar to `query_perp_deploy_auction_status`:

```python
    def query_spot_deploy_auction_status(self, user: str) -> Any:
        return self.post("/info", {"type": "spotDeployState", "user": user})
```