### PR TITLE
feature: add staking to spot transfer api

### DIFF
--- a/hyperliquid/exchange.py
+++ b/hyperliquid/exchange.py
@@ -31,7 +31,7 @@ from hyperliquid.utils.signing import (
     sign_token_delegate_action,
     sign_usd_class_transfer_action,
     sign_usd_transfer_action,
-    sign_withdraw_from_bridge_action,
+    sign_withdraw_from_bridge_action, sign_staking_to_spot_transfer_action,
 )
 from hyperliquid.utils.types import (
     Any,
@@ -1113,3 +1113,18 @@ class Exchange(API):
             self.wallet, action, self.vault_address, nonce, self.expires_after, self.base_url == MAINNET_API_URL
         )
         return self._post_action(action, signature, nonce)
+
+    def staking_to_spot_transfer(self, wei: int) -> Any:
+        timestamp = get_timestamp_ms()
+        action = {
+            "wei": wei,
+            "nonce": timestamp,
+            "type": "cWithdraw",
+        }
+        is_mainnet = self.base_url == MAINNET_API_URL
+        signature = sign_staking_to_spot_transfer_action(self.wallet, action, is_mainnet)
+        return self._post_action(
+            action,
+            signature,
+            timestamp,
+        )

--- a/hyperliquid/utils/signing.py
+++ b/hyperliquid/utils/signing.py
@@ -135,6 +135,12 @@ MULTI_SIG_ENVELOPE_SIGN_TYPES = [
     {"name": "nonce", "type": "uint64"},
 ]
 
+STAKING_TO_SPOT_TRANSFER_SIGN_TYPES = [
+    {"name": "hyperliquidChain", "type": "string"},
+    {"name": "wei", "type": "uint64"},
+    {"name": "nonce", "type": "uint64"},
+]
+
 
 def order_type_to_wire(order_type: OrderType) -> OrderTypeWire:
     if "limit" in order_type:
@@ -488,3 +494,12 @@ def order_wires_to_order_action(order_wires, builder=None):
     if builder:
         action["builder"] = builder
     return action
+
+def sign_staking_to_spot_transfer_action(wallet, action, is_mainnet):
+    return sign_user_signed_action(
+        wallet,
+        action,
+        STAKING_TO_SPOT_TRANSFER_SIGN_TYPES,
+        "HyperliquidTransaction:CWithdraw",
+        is_mainnet,
+    )


### PR DESCRIPTION
### Summary
Add missing staking_to_spot_transfer API support.

### Motivation
The SDK did not previously provide a method to transfer from staking to spot, even though the API endpoint exists.
This PR adds the missing feature to align the Python SDK with the latest Hyperliquid API capabilities.

### Changes
- hyperliquid/exchange.py : Added staking_to_spot_transfer method in the Exchange class.
- hyperliquid/utils/signing.py : Added signing action method for staking-to-spot transfer. 