### PR TITLE
Restoring Backward Compatibility for `perp_deploy_set_oracle` Function

### DIFF
--- a/hyperliquid/exchange.py
+++ b/hyperliquid/exchange.py
@@ -910,21 +910,22 @@ class Exchange(API):
         dex: str,
         oracle_pxs: Dict[str, str],
         all_mark_pxs: List[Dict[str, str]],
-        external_perp_pxs: Dict[str, str],
+        external_perp_pxs: Optional[Dict[str, str]] = None,
     ) -> Any:
         timestamp = get_timestamp_ms()
         oracle_pxs_wire = sorted(list(oracle_pxs.items()))
         mark_pxs_wire = [sorted(list(mark_pxs.items())) for mark_pxs in all_mark_pxs]
-        external_perp_pxs_wire = sorted(list(external_perp_pxs.items()))
         action = {
             "type": "perpDeploy",
             "setOracle": {
                 "dex": dex,
                 "oraclePxs": oracle_pxs_wire,
                 "markPxs": mark_pxs_wire,
-                "externalPerpPxs": external_perp_pxs_wire,
             },
         }
+        if external_perp_pxs is not None:
+            external_perp_pxs_wire = sorted(list(external_perp_pxs.items()))
+            action["setOracle"]["externalPerpPxs"] = external_perp_pxs_wire
         signature = sign_l1_action(
             self.wallet,
             action,

--- a/tests/exchange_test.py
+++ b/tests/exchange_test.py
@@ -1,0 +1,63 @@
+from typing import Dict
+
+from eth_account import Account
+
+from hyperliquid.exchange import Exchange
+
+TEST_META = {"universe": []}
+TEST_SPOT_META = {"universe": [], "tokens": {}}
+
+
+def _make_exchange(monkeypatch):
+    wallet = Account.create()
+    exchange = Exchange(
+        wallet,
+        base_url="https://api.hyperliquid.xyz",
+        meta=TEST_META,
+        spot_meta=TEST_SPOT_META,
+    )
+
+    monkeypatch.setattr("hyperliquid.exchange.get_timestamp_ms", lambda: 1)
+    monkeypatch.setattr("hyperliquid.exchange.sign_l1_action", lambda *_, **__: "signature")
+
+    captured: Dict[str, Dict[str, object]] = {}
+
+    def fake_post(path: str, payload: Dict[str, object]) -> Dict[str, object]:
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"status": "ok"}
+
+    monkeypatch.setattr(exchange, "post", fake_post)
+
+    return exchange, captured
+
+
+def test_perp_deploy_set_oracle_without_external_prices(monkeypatch):
+    exchange, captured = _make_exchange(monkeypatch)
+
+    exchange.perp_deploy_set_oracle(
+        "test-dex",
+        {"TEST:ASSET": "1.0"},
+        [{"TEST:ASSET": "2.0"}],
+    )
+
+    assert captured["path"] == "/exchange"
+    action = captured["payload"]["action"]["setOracle"]
+    assert action["dex"] == "test-dex"
+    assert action["oraclePxs"] == [("TEST:ASSET", "1.0")]
+    assert action["markPxs"] == [[("TEST:ASSET", "2.0")]]
+    assert "externalPerpPxs" not in action
+
+
+def test_perp_deploy_set_oracle_with_external_prices(monkeypatch):
+    exchange, captured = _make_exchange(monkeypatch)
+
+    exchange.perp_deploy_set_oracle(
+        "test-dex",
+        {"TEST:ASSET": "1.0"},
+        [{"TEST:ASSET": "2.0"}],
+        external_perp_pxs={"OTHER:ASSET": "3.0"},
+    )
+
+    action = captured["payload"]["action"]["setOracle"]
+    assert action["externalPerpPxs"] == [("OTHER:ASSET", "3.0")]


### PR DESCRIPTION
## Description

In this update, backward compatibility for the `perp_deploy_set_oracle` function in the `Exchange` module has been restored. A breaking change introduced in commit `64b252e` made the `external_perp_pxs` argument required, which caused issues with existing client code that relied on the previous signature. The fix makes the `external_perp_pxs` argument optional again and ensures it is serialized only when provided.

Additionally, regression tests were added to ensure that the payload emitted by `perp_deploy_set_oracle` behaves correctly both with and without the `external_perp_pxs` argument, preventing future regressions.

## Fix Summary
- Restored optional nature of `external_perp_pxs` in `perp_deploy_set_oracle`.
- Conditioned the serialization of `external_perp_pxs` based on its presence.
- Added regression tests to validate behavior with and without `external_perp_pxs`.

## Files Modified
- `hyperliquid/exchange.py`: Updated to restore backward compatibility and handle `external_perp_pxs` conditionally.
- `tests/exchange_test.py`: New test file created to validate the updated behavior of `perp_deploy_set_oracle`.

## Testing
- All tests passed with `pytest` on the newly added tests in `tests/exchange_test.py`.