### PR TITLE
Add reserveRequestWeight to Exchange

### DIFF
--- a/hyperliquid/exchange.py
+++ b/hyperliquid/exchange.py
@@ -1160,3 +1160,23 @@ class Exchange(API):
             self.wallet, action, self.vault_address, nonce, self.expires_after, self.base_url == MAINNET_API_URL
         )
         return self._post_action(action, signature, nonce)
+
+    def reserve_request_weight(self, weight: int) -> Any:
+        timestamp = get_timestamp_ms()
+        reserve_action = {
+            "type": "reserveRequestWeight",
+            "weight": weight,
+        }
+        signature = sign_l1_action(
+            self.wallet,
+            reserve_action,
+            self.vault_address,
+            timestamp,
+            self.expires_after,
+            self.base_url == MAINNET_API_URL,
+        )
+        return self._post_action(
+            reserve_action,
+            signature,
+            timestamp,
+        )


### PR DESCRIPTION
At least in testnet, the HIP-3 SetOracle action counts toward [address-based limits](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/rate-limits-and-user-limits#address-based-limits), which is unfortunate given the frequency of updates and that these would be non-trading accounts. As such, we need to make use of [reserving actions](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#reserve-additional-actions) at 0.0005 USDC a pop.