### PR TITLE
feat: allow Exchange to accept BaseAccount signers

### DIFF
--- a/examples/basic_agent.py
+++ b/examples/basic_agent.py
@@ -1,6 +1,6 @@
 import eth_account
 import example_utils
-from eth_account.signers.local import LocalAccount
+from eth_account.signers.base import BaseAccount
 
 from hyperliquid.exchange import Exchange
 from hyperliquid.utils import constants
@@ -36,7 +36,7 @@ def main():
 
     # Create the agent's local account using the agent's private key.
     # We use `eth_account.Account.from_key()` to securely generate the agent's account from its private key.
-    agent_account: LocalAccount = eth_account.Account.from_key(agent_key)
+    agent_account: BaseAccount = eth_account.Account.from_key(agent_key)
     print("Running with agent address:", agent_account.address)
 
     # Create a new exchange instance for the agent, providing it with the agent's account information and exchange URL.
@@ -68,7 +68,7 @@ def main():
         return
 
     # Create the extra agent account using its private key and the same process as above.
-    extra_agent_account: LocalAccount = eth_account.Account.from_key(extra_agent_key)
+    extra_agent_account: BaseAccount = eth_account.Account.from_key(extra_agent_key)
     extra_agent_exchange = Exchange(extra_agent_account, constants.TESTNET_API_URL, account_address=address)
     print("Running with extra agent address:", extra_agent_account.address)
 

--- a/examples/evm_erc20.py
+++ b/examples/evm_erc20.py
@@ -2,7 +2,7 @@ from typing import Literal, TypedDict, Union
 
 import requests
 from eth_account import Account
-from eth_account.signers.local import LocalAccount
+from eth_account.signers.base import BaseAccount
 from web3 import Web3
 from web3.middleware import SignAndSendRawMiddlewareBuilder
 
@@ -43,7 +43,7 @@ w3 = Web3(Web3.HTTPProvider(rpc_url))
 # You can also switch this to create an account a different way if you don't want to include a secret key in code
 if PRIVATE_KEY == "0xPRIVATE_KEY":
     raise Exception("must set private key or create account another way")
-account: LocalAccount = Account.from_key(PRIVATE_KEY)
+account: BaseAccount = Account.from_key(PRIVATE_KEY)
 print(f"Running with address {account.address}")
 w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(account))
 w3.eth.default_account = account.address

--- a/examples/example_utils.py
+++ b/examples/example_utils.py
@@ -3,7 +3,7 @@ import json
 import os
 
 import eth_account
-from eth_account.signers.local import LocalAccount
+from eth_account.signers.base import BaseAccount
 
 from hyperliquid.exchange import Exchange
 from hyperliquid.info import Info
@@ -13,7 +13,7 @@ def setup(base_url=None, skip_ws=False, perp_dexs=None):
     config_path = os.path.join(os.path.dirname(__file__), "config.json")
     with open(config_path) as f:
         config = json.load(f)
-    account: LocalAccount = eth_account.Account.from_key(get_secret_key(config))
+    account: BaseAccount = eth_account.Account.from_key(get_secret_key(config))
     address = config["account_address"]
     if address == "":
         address = account.address
@@ -59,7 +59,7 @@ def setup_multi_sig_wallets():
 
     authorized_user_wallets = []
     for wallet_config in config["multi_sig"]["authorized_users"]:
-        account: LocalAccount = eth_account.Account.from_key(wallet_config["secret_key"])
+        account: BaseAccount = eth_account.Account.from_key(wallet_config["secret_key"])
         address = wallet_config["account_address"]
         if account.address != address:
             raise Exception(f"provided authorized user address {address} does not match private key")

--- a/hyperliquid/exchange.py
+++ b/hyperliquid/exchange.py
@@ -3,7 +3,7 @@ import logging
 import secrets
 
 import eth_account
-from eth_account.signers.local import LocalAccount
+from eth_account.signers.base import BaseAccount
 
 from hyperliquid.api import API
 from hyperliquid.info import Info
@@ -59,7 +59,7 @@ class Exchange(API):
 
     def __init__(
         self,
-        wallet: LocalAccount,
+        wallet: BaseAccount,
         base_url: Optional[str] = None,
         meta: Optional[Meta] = None,
         vault_address: Optional[str] = None,


### PR DESCRIPTION
#215 Switch `Exchange` (and examples) to accept `eth_account.signers.base.BaseAccount`.

Only type annotations/imports changed, no runtime logic touched. Please approve the workflow run so CI can execute!