### PR TITLE
feat: add halt trading action for HIP-3 perps

### DIFF
--- a/examples/perp_deploy.py
+++ b/examples/perp_deploy.py
@@ -10,6 +10,12 @@ from hyperliquid.utils import constants
 REGISTER_PERP_DEX = False
 
 DUMMY_DEX = "test"
+COIN_0 = f"{DUMMY_DEX}:TEST0"
+COIN_1 = f"{DUMMY_DEX}:TEST1"
+
+# Trading on a newly deployed perp is halted by default.
+# Set to True to enable trading on the new perp.
+ENABLE_TRADING = True
 
 
 def main():
@@ -34,7 +40,7 @@ def main():
     register_asset_result = exchange.perp_deploy_register_asset(
         dex=DUMMY_DEX,
         max_gas=1000000000000,
-        coin=f"{DUMMY_DEX}:TEST0",
+        coin=COIN_0,
         sz_decimals=2,
         oracle_px="10.0",
         margin_table_id=10,
@@ -45,24 +51,28 @@ def main():
     # If registration is successful, the "dex" that was used can serve as the index into this clearinghouse for later asset
     # registrations and oracle updates.
 
+    if ENABLE_TRADING:
+        print(f"\nEnabling trading on {COIN_0}...")
+        halt_result = exchange.perp_deploy_halt_trading(coin=COIN_0, is_halted=False)
+
     # Step 2: Set the Oracle Prices
     #
     # Oracle updates can be sent multiple times
     set_oracle_result = exchange.perp_deploy_set_oracle(
         DUMMY_DEX,
         {
-            f"{DUMMY_DEX}:TEST0": "12.0",
-            f"{DUMMY_DEX}:TEST1": "1.0",
+            COIN_0: "12.0",
+            COIN_1": "1.0",
         },
         [
             {
-                f"{DUMMY_DEX}:TEST1": "3.0",
-                f"{DUMMY_DEX}:TEST0": "14.0",
+                COIN_1: "3.0",
+                COIN_0: "14.0",
             }
         ],
         {
-            f"{DUMMY_DEX}:TEST0": "12.1",
-            f"{DUMMY_DEX}:TEST1": "1.1",
+            COIN_0: "12.1",
+            COIN_1: "1.1",
         },
     )
     print("set oracle result:", set_oracle_result)

--- a/hyperliquid/exchange.py
+++ b/hyperliquid/exchange.py
@@ -949,6 +949,29 @@ class Exchange(API):
             timestamp,
         )
 
+    def perp_deploy_halt_trading(self, coin: str, is_halted: bool) -> Any:
+        timestamp = get_timestamp_ms()
+        action = {
+            "type": "perpDeploy",
+            "haltTrading": {
+                "coin": coin,
+                "isHalted": is_halted,
+            },
+        }
+        signature = sign_l1_action(
+            self.wallet,
+            action,
+            None,
+            timestamp,
+            self.expires_after,
+            self.base_url == MAINNET_API_URL,
+        )
+        return self._post_action(
+            action,
+            signature,
+            timestamp,
+        )
+
     def c_signer_unjail_self(self) -> Any:
         return self.c_signer_inner("unjailSelf")
 


### PR DESCRIPTION
Trading seems halted by default for new perp deployments so it makes sense to include the enabling of it in the default process / example.