### PR TITLE
fix: Info.query_order_by_oid returns unknownOid sometimes

### DIFF
--- a/hyperliquid/info.py
+++ b/hyperliquid/info.py
@@ -608,11 +608,35 @@ class Info(API):
         """
         return self.post("/info", {"type": "delegatorHistory", "user": user})
 
-    def query_order_by_oid(self, user: str, oid: int) -> Any:
-        return self.post("/info", {"type": "orderStatus", "user": user, "oid": oid})
+    def query_order_by_oid(self, user: str, oid: int, dex: str = "") -> Any:
+        """Query order status by order ID.
 
-    def query_order_by_cloid(self, user: str, cloid: Cloid) -> Any:
-        return self.post("/info", {"type": "orderStatus", "user": user, "oid": cloid.to_raw()})
+        POST /info
+
+        Args:
+            user (str): Onchain address in 42-character hexadecimal format.
+            oid (int): Order ID.
+            dex (str): Optional DEX identifier (defaults to "" for the original DEX).
+
+        Returns:
+            Order status.
+        """
+        return self.post("/info", {"type": "orderStatus", "user": user, "oid": oid, "dex": dex})
+
+    def query_order_by_cloid(self, user: str, cloid: Cloid, dex: str = "") -> Any:
+        """Query order status by client order ID.
+
+        POST /info
+
+        Args:
+            user (str): Onchain address in 42-character hexadecimal format.
+            cloid (Cloid): Client order ID.
+            dex (str): Optional DEX identifier (defaults to "" for the original DEX).
+
+        Returns:
+            Order status.
+        """
+        return self.post("/info", {"type": "orderStatus", "user": user, "oid": cloid.to_raw(), "dex": dex})
 
     def query_referral_state(self, user: str) -> Any:
         return self.post("/info", {"type": "referral", "user": user})


### PR DESCRIPTION
## Summary

This PR fixes issue #253 where `Info.query_order_by_oid` was returning "unknownOid" when querying orders on non-default DEXes. The root cause was that the method was missing the `dex` parameter that other order-related methods (`open_orders`, etc.) support.

## Changes

- Added `dex: str = ""` parameter to `Info.query_order_by_oid()` method
- Added `dex: str = ""` parameter to `Info.query_order_by_cloid()` method for consistency
- Updated both methods to pass the `dex` parameter in the API request body
- Added comprehensive docstrings documenting the new parameter

## Testing

- Existing tests pass where network requests are mocked
- The fix maintains backward compatibility (default `dex=""`)
- When querying orders fetched via `open_orders(dex="...")`, you must now pass the same `dex` value to `query_order_by_oid()` to locate the order

Fixes hyperliquid-dex/hyperliquid-python-sdk#253