### PR TITLE
fix: token info retrieval in Info and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ python examples/basic_order.py
    - Note that Poetry v2 is not supported, so you'll need to specify a specific version e.g. curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.1 python3 - 
 
 2. Point poetry to correct version of python. For development we require python 3.10 exactly. Some dependencies have issues on 3.11, while older versions don't have correct typing support.
-`brew install python@3.10 && poetry env use /opt/homebrew/Cellar/python@3.10/3.10.16/bin/python3.10`
+```
+brew install python@3.10 && poetry env use 3.10
+```
+  - You can also bind the environment directly to the Homebrew path using:`poetry env use $(brew --prefix python@3.10)/bin/python3.10`
 
 3. Install dependencies:
 

--- a/hyperliquid/info.py
+++ b/hyperliquid/info.py
@@ -39,14 +39,16 @@ class Info(API):
         self.name_to_coin = {}
         self.asset_to_sz_decimals = {}
 
+        token_index_to_token_info = {token_info["index"]: token_info for token_info in spot_meta["tokens"]}
+
         # spot assets start at 10000
         for spot_info in spot_meta["universe"]:
             asset = spot_info["index"] + 10000
             self.coin_to_asset[spot_info["name"]] = asset
             self.name_to_coin[spot_info["name"]] = spot_info["name"]
             base, quote = spot_info["tokens"]
-            base_info = spot_meta["tokens"][base]
-            quote_info = spot_meta["tokens"][quote]
+            base_info = token_index_to_token_info[base]
+            quote_info = token_index_to_token_info[quote]
             self.asset_to_sz_decimals[asset] = base_info["szDecimals"]
             name = f'{base_info["name"]}/{quote_info["name"]}'
             if name not in self.name_to_coin:


### PR DESCRIPTION
- The Issue: The universe tokens were being accessed via list position, but the API's list index and the token's internal index are not always 1:1.

  The Fix: Implemented a token_index_to_token_info lookup table to map metadata by the actual token ID.
- Homebrew paths for specific versions (like 3.10.16) change whenever the patch version updates. Using brew --prefix ensures the command remains valid even after brew upgrade, preventing broken environment setups.

fix #275 