### PR TITLE
Fix typo in subscription comment

### DIFF
--- a/hyperliquid/utils/types.py
+++ b/hyperliquid/utils/types.py
@@ -53,7 +53,7 @@ ActiveAssetCtxSubscription = TypedDict("ActiveAssetCtxSubscription", {"type": Li
 ActiveAssetDataSubscription = TypedDict(
     "ActiveAssetDataSubscription", {"type": Literal["activeAssetData"], "user": str, "coin": str}
 )
-# If adding new subscription types that contain coin's don't forget to handle automatically rewrite name to coin in info.subscribe
+# If adding new subscription types that contain coins, don't forget to automatically rewrite name to coin in info.subscribe
 Subscription = Union[
     AllMidsSubscription,
     BboSubscription,


### PR DESCRIPTION
Corrects "coin's" -> "coins" and fixes the broken verb phrase in the inline comment.